### PR TITLE
'fun' must be separated from following atom

### DIFF
--- a/syntaxes/erlang.tmLanguage
+++ b/syntaxes/erlang.tmLanguage
@@ -751,7 +751,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(fun)\s*+(([a-z][a-zA-Z\d@_]*+)\s*+(:)\s*+)?([a-z][a-zA-Z\d@_]*+)\s*(/)</string>
+					<string>\b(fun)\s+(([a-z][a-zA-Z\d@_]*+)\s*+(:)\s*+)?([a-z][a-zA-Z\d@_]*+)\s*(/)</string>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
In `fun F/A` expressions (and similar), the keyword must be separated from the following atom.

Otherwise we match `function`, for example.