### PR TITLE
Fix a typo in filename

### DIFF
--- a/lib/erlangDebugSession.ts
+++ b/lib/erlangDebugSession.ts
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events'
 import * as http from 'http';
 import * as vscode from 'vscode';
 import * as erlang from './ErlangShell';
-import { ErlangConnection, erlangBridgePath } from './ErlangConnection';
+import { ErlangConnection, erlangBridgePath } from './erlangConnection';
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	cwd: string;


### PR DESCRIPTION
Due to a typo in file name Erlang debugging does not work on Linux where file system is normally case sensitive