### PR TITLE
Fixes for process management during debugging

### DIFF
--- a/apps/erlangbridge/src/vscode_connection.erl
+++ b/apps/erlangbridge/src/vscode_connection.erl
@@ -257,6 +257,9 @@ decode_debugger_message(VsCodePort, M) ->
     %                               {mymodule_app,start,[normal,[]]},
     %                               running,{}}}
     case M of
+    {new_process, {_Pid, {_Module, module_info, _Args}, _Status, _Other}} ->
+        % ignore processes calling module_info started by debugger itself
+        ok;
     {Verb, Data} ->
         send_message_to_vscode(VsCodePort,to_string(Verb), to_json(Verb, Data));
     {new_status,Pid,idle,_} ->

--- a/apps/erlangbridge/src/vscode_connection.erl
+++ b/apps/erlangbridge/src/vscode_connection.erl
@@ -272,6 +272,9 @@ decode_debugger_message(VsCodePort, M) ->
     {new_status,Pid,running,_} ->
         %{new_status,<0.3.0>,running,{}}
         send_message_to_vscode(VsCodePort,to_string(new_status), to_json(new_status, {Pid, running}));
+    {new_status,_,waiting,_} ->
+        %{new_status,<0.3.0>,waiting,{}}: no output not to pollute the console
+        ok;
     _ -> 
         io:format("decode debugger receive : ~p~n", [M])    
     end,

--- a/lib/erlangDebugSession.ts
+++ b/lib/erlangDebugSession.ts
@@ -350,6 +350,15 @@ export class ErlangDebugSession extends DebugSession implements IErlangShellOutp
 			if (fs.existsSync(path.join(this._LaunchArguments.cwd, "apps", relative))) {
 				ret = path.join(this._LaunchArguments.cwd, "apps", relative);
 			}
+			else {
+				var basedirname = path.parse(this._LaunchArguments.cwd).base;
+				if (relative.startsWith(basedirname + path.sep)) {
+					var converted = path.join(this._LaunchArguments.cwd, "..", relative);
+					if (fs.existsSync(converted)) {
+						ret = converted;
+					}
+				}
+			}
 		}
 		return ret;
 	}

--- a/lib/erlangDebugSession.ts
+++ b/lib/erlangDebugSession.ts
@@ -148,6 +148,7 @@ export class ErlangDebugSession extends DebugSession implements IErlangShellOutp
 			this.erlangConnection.Quit();
 		}
 		this.sendResponse(response);
+		this.erlDebugger.CleanupAfterStart();
 	}
 
 
@@ -155,6 +156,7 @@ export class ErlangDebugSession extends DebugSession implements IErlangShellOutp
 		this.log(`erl exit with code ${exitCode}`);
 		this.quit = true;
 		this.sendEvent(new TerminatedEvent());
+		this.erlDebugger.CleanupAfterStart();
 	}
 
 	protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {


### PR DESCRIPTION
The plugin manages debugging on the base of the list of running Erlang processes - this list is threadIDs in erlangDebugSession.ts. When the last process in the list finishes and sends "exited" event, debugging quits by calling q().

However, there are some problems with the management of processes list. Not all processes which should be there are there, and some processes which should not be there are on the list.

Processes are added to threadIDs when an event from the debugger about the process is received. But debugger sends only events about interpreted modules - the ones on which int:i was called - and the plugin currently interprets a module only after a breakpoint is set there. 

This caused the behaviour which I observed: I start debugging, then I set the first breakpoint in some module, and when a process defined in this module exits, the entire debugging session exits as well, since the process which exited was the only entry in threadIDs, so it was treated as the last process in the session.

Another problem is that after a module is added by calling int:i, sometimes debugger starts a process calling this module's module_info function. This process is added to threadIDs but never removed from there, so the debugging session never ends. 

The pull request fixes both problems. The first one is fixed by adding all Erlang sources from the project directory to the debugger on startup. The second one is fixed by ignoring module_info processes. Additionally, to fix the first problem and not exceed command line length limitation, I introduced passing parameters to erlang not directly in the command line but in a temporary file.