### PR TITLE
Console quiet by default

### DIFF
--- a/apps/erlangbridge/src/vscode_connection.erl
+++ b/apps/erlangbridge/src/vscode_connection.erl
@@ -125,6 +125,8 @@ decode_request(Data) ->
         catch
             _:Exp -> #{value => iolist_to_binary(io_lib:format("~p", [Exp])), type => <<"error">>}    
         end;
+    {debugger_exit, _Body} ->
+        init:stop(0);
     _ ->
         unknown_command
     end.

--- a/lib/ErlangShellDebugger.ts
+++ b/lib/ErlangShellDebugger.ts
@@ -30,7 +30,7 @@ export class ErlangShellForDebugging extends ErlGenericShell {
     public Start(erlPath:string, startDir: string, listen_port: number, bridgePath: string, args: string, noDebug: boolean): Promise<boolean> {
         var randomSuffix:string = Math.floor(Math.random() * 10000000).toString();
         this.argsFileName = path.join(os.tmpdir(), path.basename(startDir) + '_' + randomSuffix);
-        var debugStartArgs = ["-pa", `"${bridgePath}"`, "-s", "int",
+        var debugStartArgs = ["-noshell", "-pa", `"${bridgePath}"`, "-s", "int",
             "-vscode_port", listen_port.toString(),
             "-s", "vscode_connection", "start", listen_port.toString()];
         var breakPointsAndModulesArgs = this.breakpointsAndModules(startDir, noDebug);

--- a/lib/GenericShell.ts
+++ b/lib/GenericShell.ts
@@ -155,10 +155,4 @@ export class ErlGenericShell extends EventEmitter {
             this.erlangShell.kill();
         }
     }
-
-    public NormalQuit() {
-        if (this.erlangShell) {
-            this.Send("q().");
-        }
-    }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
 								"type": "string",
 								"description": "Path to the erl executable or the command if in PATH",
 								"default": "erl"
+							},
+							"verbose": {
+								"type": "boolean",
+								"description": "Should extended debugging details be logged",
+								"default": false
 							}
 						}
 					}
@@ -191,10 +196,10 @@
 		"vscode-debugprotocol": "^1.16.0"
 	},
 	"devDependencies": {
-		"typescript": "^2.0.3",
-		"vscode": "^1.0.0",
+		"@types/mocha": "^2.2.48",
+		"@types/node": "^6.0.101",
 		"mocha": "^2.3.3",
-		"@types/node": "^6.0.40",
-		"@types/mocha": "^2.2.32"
+		"typescript": "^2.7.2",
+		"vscode": "^1.1.10"
 	}
 }


### PR DESCRIPTION
By default the debug console shows only the output of the debugged code. To restore most of the previous messages use "verbose" option in launch.json. Also, "1>" string are no longer displayed in the console by the shell, since debugger is started with -noshell option, and to quit init:stop is used instead of q().