### PR TITLE
Add standard include directory to include paths

### DIFF
--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -126,7 +126,23 @@ get_settings_include_paths() ->
     end, SettingPaths).
 
 get_file_include_paths(File) ->
-    [filename:dirname(File), filename:rootname(File)].
+    Paths = [filename:dirname(File), filename:rootname(File)],
+    case get_file_include_directory(File) of
+        undefined ->
+            Paths;
+        Path ->
+            [Path|Paths]
+    end.
+
+get_file_include_directory(File) ->
+    case lists:reverse(filename:split(filename:dirname(File))) of
+        ["src"|Rest] ->
+            filename:join(lists:reverse(["include"|Rest]));
+        [_, "src"|Rest] ->
+            filename:join(lists:reverse(["include"|Rest]));
+        _Other ->
+            undefined
+    end.
 
 get_define_from_rebar_config(File) ->
     RebarConfig = find_rebar_config(filename:dirname(File)),


### PR DESCRIPTION
The recommended erlang directors structure at http://erlang.org/doc/design_principles/applications.html#id81839 allows an optional include directory for shared header files next to the src directory. It is however left to the build tool to ensure this directory is added to the include paths.

Using this structure, the linter does not find headers in the include directory and generates spurious errors.

This PR checks whether the file being linted is located in a src directory, or one directory deep under a src directory (the maximum depth recommended in the suggested erlang development directory structure), and if so adds an include directory next to that src directory to the list of possible include paths.