### PR TITLE
Also recognize the .xrl (leex) extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 				"extensions": [
 					".erl",
 					".hrl",
+					".xrl",
 					".yrl",
 					".escript",
 					".app.src",


### PR DESCRIPTION
leex (http://erlang.org/doc/man/leex.html) input files use the .xrl
extension. They can contain comments, definitions, rules, and Erlang
code.