### PR TITLE
Fix erlangPath setting for Linux/OSX

### DIFF
--- a/lib/GenericShell.ts
+++ b/lib/GenericShell.ts
@@ -60,7 +60,8 @@ export class ErlGenericShell extends EventEmitter {
                 var childEnv = null;
                 if (this.erlangPath) {
                     childEnv = process.env;
-                    childEnv.PATH = this.erlangPath +";"+childEnv.PATH
+                    var separator = process.platform == 'win32' ? ";" : ":";
+                    childEnv.PATH = this.erlangPath + separator + childEnv.PATH;
                 }
 
                 this.erlangShell = spawn(processName, args, { cwd: startDir, shell: true, stdio: 'pipe', env : childEnv });


### PR DESCRIPTION
erlangPath wasn't working for me on linux. Tracked it down to a ; being used as a path separator when setting up the env instead of a :. This PR fixes that for non-widows systems.