### PR TITLE
Fix includes for linting of test files

### DIFF
--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -147,9 +147,9 @@ get_file_include_paths(File) ->
 
 get_file_include_directory(File) ->
     case lists:reverse(filename:split(filename:dirname(File))) of
-        ["src"|Rest] ->
+        [DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
             filename:join(lists:reverse(["include"|Rest]));
-        [_, "src"|Rest] ->
+        [_, DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
             filename:join(lists:reverse(["include"|Rest]));
         _Other ->
             undefined


### PR DESCRIPTION
http://erlang.org/doc/design_principles/applications.html#7.4 suggests
tests be stored in a `test` directory alongside the `src` directory and
a potential `include` directory. This commit fixes linting of tests
which include files from the aforementioned `include` directory.