### PR TITLE
Improve syntax highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.dump
 _build/
 /syntaxes/*.yaml
+/syntaxes/*.yaml-tmLanguage

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -24,10 +24,12 @@ from _Ben Hockley_.
   [plist-yaml-plist](https://github.com/grahampugh/plist-yaml-plist)
   from Github and use below commands: (On Windows use WSL)
 
-      /path/to/plist_yaml.py erlang.tmLanguage erlang.tmLanguage.yaml
+      /path/to/plist_yaml.py erlang.tmLanguage erlang.yaml-tmLanguage
       # Edit YAML file here ... then if you are ready convert back to PLIST
-      /path/to/yaml_plist.py erlang.tmLanguage.yaml erlang.tmLanguage
+      /path/to/yaml_plist.py erlang.yaml-tmLanguage erlang.tmLanguage
 
 ## References
 
 1. Visual Studio Code [Syntax Highlight Guide](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide)
+2. TextMate [Language Grammars](https://macromates.com/manual/en/language_grammars)
+3. [Writing a TextMate Grammar: Some Lessons Learned](https://www.apeth.com/nonblog/stories/textmatebundle.html)

--- a/syntaxes/erlang.tmLanguage
+++ b/syntaxes/erlang.tmLanguage
@@ -101,7 +101,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x\h{2})</string>
 							<key>name</key>
 							<string>constant.other.symbol.escape.erlang</string>
 						</dict>
@@ -243,7 +243,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}))</string>
+					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x\h{2}))</string>
 					<key>name</key>
 					<string>constant.character.erlang</string>
 				</dict>
@@ -263,7 +263,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$)\S</string>
+					<string>(\$)[ \S]</string>
 					<key>name</key>
 					<string>constant.character.erlang</string>
 				</dict>
@@ -563,6 +563,10 @@
 				<dict>
 					<key>include</key>
 					<string>#textual-operator</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#language-constant</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1605,11 +1609,21 @@
 						<key>5</key>
 						<dict>
 							<key>name</key>
+							<string>punctuation.separator.unit-specifiers.erlang</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.integer.decimal.erlang</string>
+						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
 							<string>punctuation.separator.type-specifiers.erlang</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(integer|float|binary|bytes|bitstring|bits)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
+					<string>(integer|float|binary|bytes|bitstring|bits|utf8|utf16|utf32)|(signed|unsigned)|(big|little|native)|(unit)(:)(\d++)|(-)</string>
 				</dict>
 			</array>
 		</dict>
@@ -1619,6 +1633,13 @@
 			<string>\b(after|begin|case|catch|cond|end|fun|if|let|of|query|try|receive|when)\b</string>
 			<key>name</key>
 			<string>keyword.control.erlang</string>
+		</dict>
+		<key>language-constant</key>
+		<dict>
+			<key>match</key>
+			<string>\b(false|true|undefined)\b</string>
+			<key>name</key>
+			<string>constant.language</string>
 		</dict>
 		<key>list</key>
 		<dict>
@@ -1878,7 +1899,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>2(#)[0-1]++</string>
+					<string>2(#)([0-1]++_)*[0-1]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.binary.erlang</string>
 				</dict>
@@ -1892,7 +1913,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>3(#)[0-2]++</string>
+					<string>3(#)([0-2]++_)*[0-2]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-3.erlang</string>
 				</dict>
@@ -1906,7 +1927,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>4(#)[0-3]++</string>
+					<string>4(#)([0-3]++_)*[0-3]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-4.erlang</string>
 				</dict>
@@ -1920,7 +1941,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>5(#)[0-4]++</string>
+					<string>5(#)([0-4]++_)*[0-4]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-5.erlang</string>
 				</dict>
@@ -1934,7 +1955,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>6(#)[0-5]++</string>
+					<string>6(#)([0-5]++_)*[0-5]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-6.erlang</string>
 				</dict>
@@ -1948,7 +1969,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>7(#)[0-6]++</string>
+					<string>7(#)([0-6]++_)*[0-6]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-7.erlang</string>
 				</dict>
@@ -1962,7 +1983,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>8(#)[0-7]++</string>
+					<string>8(#)([0-7]++_)*[0-7]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.octal.erlang</string>
 				</dict>
@@ -1976,7 +1997,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>9(#)[0-8]++</string>
+					<string>9(#)([0-8]++_)*[0-8]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-9.erlang</string>
 				</dict>
@@ -1990,7 +2011,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>10(#)\d++</string>
+					<string>10(#)(\d++_)*\d++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.decimal.erlang</string>
 				</dict>
@@ -2004,7 +2025,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>11(#)[\daA]++</string>
+					<string>11(#)([\daA]++_)*[\daA]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-11.erlang</string>
 				</dict>
@@ -2018,7 +2039,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>12(#)[\da-bA-B]++</string>
+					<string>12(#)([\da-bA-B]++_)*[\da-bA-B]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-12.erlang</string>
 				</dict>
@@ -2032,7 +2053,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>13(#)[\da-cA-C]++</string>
+					<string>13(#)([\da-cA-C]++_)*[\da-cA-C]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-13.erlang</string>
 				</dict>
@@ -2046,7 +2067,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>14(#)[\da-dA-D]++</string>
+					<string>14(#)([\da-dA-D]++_)*[\da-dA-D]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-14.erlang</string>
 				</dict>
@@ -2060,7 +2081,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>15(#)[\da-eA-E]++</string>
+					<string>15(#)([\da-eA-E]++_)*[\da-eA-E]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-15.erlang</string>
 				</dict>
@@ -2074,7 +2095,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>16(#)\h++</string>
+					<string>16(#)(\h++_)*\h++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.hexadecimal.erlang</string>
 				</dict>
@@ -2088,7 +2109,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>17(#)[\da-gA-G]++</string>
+					<string>17(#)([\da-gA-G]++_)*[\da-gA-G]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-17.erlang</string>
 				</dict>
@@ -2102,7 +2123,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>18(#)[\da-hA-H]++</string>
+					<string>18(#)([\da-hA-H]++_)*[\da-hA-H]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-18.erlang</string>
 				</dict>
@@ -2116,7 +2137,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>19(#)[\da-iA-I]++</string>
+					<string>19(#)([\da-iA-I]++_)*[\da-iA-I]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-19.erlang</string>
 				</dict>
@@ -2130,7 +2151,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>20(#)[\da-jA-J]++</string>
+					<string>20(#)([\da-jA-J]++_)*[\da-jA-J]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-20.erlang</string>
 				</dict>
@@ -2144,7 +2165,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>21(#)[\da-kA-K]++</string>
+					<string>21(#)([\da-kA-K]++_)*[\da-kA-K]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-21.erlang</string>
 				</dict>
@@ -2158,7 +2179,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>22(#)[\da-lA-L]++</string>
+					<string>22(#)([\da-lA-L]++_)*[\da-lA-L]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-22.erlang</string>
 				</dict>
@@ -2172,7 +2193,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>23(#)[\da-mA-M]++</string>
+					<string>23(#)([\da-mA-M]++_)*[\da-mA-M]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-23.erlang</string>
 				</dict>
@@ -2186,7 +2207,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>24(#)[\da-nA-N]++</string>
+					<string>24(#)([\da-nA-N]++_)*[\da-nA-N]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-24.erlang</string>
 				</dict>
@@ -2200,7 +2221,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>25(#)[\da-oA-O]++</string>
+					<string>25(#)([\da-oA-O]++_)*[\da-oA-O]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-25.erlang</string>
 				</dict>
@@ -2214,7 +2235,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>26(#)[\da-pA-P]++</string>
+					<string>26(#)([\da-pA-P]++_)*[\da-pA-P]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-26.erlang</string>
 				</dict>
@@ -2228,7 +2249,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>27(#)[\da-qA-Q]++</string>
+					<string>27(#)([\da-qA-Q]++_)*[\da-qA-Q]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-27.erlang</string>
 				</dict>
@@ -2242,7 +2263,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>28(#)[\da-rA-R]++</string>
+					<string>28(#)([\da-rA-R]++_)*[\da-rA-R]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-28.erlang</string>
 				</dict>
@@ -2256,7 +2277,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>29(#)[\da-sA-S]++</string>
+					<string>29(#)([\da-sA-S]++_)*[\da-sA-S]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-29.erlang</string>
 				</dict>
@@ -2270,7 +2291,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>30(#)[\da-tA-T]++</string>
+					<string>30(#)([\da-tA-T]++_)*[\da-tA-T]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-30.erlang</string>
 				</dict>
@@ -2284,7 +2305,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>31(#)[\da-uA-U]++</string>
+					<string>31(#)([\da-uA-U]++_)*[\da-uA-U]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-31.erlang</string>
 				</dict>
@@ -2298,7 +2319,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>32(#)[\da-vA-V]++</string>
+					<string>32(#)([\da-vA-V]++_)*[\da-vA-V]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-32.erlang</string>
 				</dict>
@@ -2312,7 +2333,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>33(#)[\da-wA-W]++</string>
+					<string>33(#)([\da-wA-W]++_)*[\da-wA-W]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-33.erlang</string>
 				</dict>
@@ -2326,7 +2347,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>34(#)[\da-xA-X]++</string>
+					<string>34(#)([\da-xA-X]++_)*[\da-xA-X]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-34.erlang</string>
 				</dict>
@@ -2340,7 +2361,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>35(#)[\da-yA-Y]++</string>
+					<string>35(#)([\da-yA-Y]++_)*[\da-yA-Y]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-35.erlang</string>
 				</dict>
@@ -2354,19 +2375,19 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>36(#)[\da-zA-Z]++</string>
+					<string>36(#)([\da-zA-Z]++_)*[\da-zA-Z]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-36.erlang</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\d++#[\da-zA-Z]++</string>
+					<string>\d++#([\da-zA-Z]++_)*[\da-zA-Z]++</string>
 					<key>name</key>
 					<string>invalid.illegal.integer.erlang</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\d++</string>
+					<string>(\d++_)*\d++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.decimal.erlang</string>
 				</dict>
@@ -2569,7 +2590,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x\h{2})</string>
 					<key>name</key>
 					<string>constant.character.escape.erlang</string>
 				</dict>

--- a/syntaxes/test/syntax_test_data_types.erl
+++ b/syntaxes/test/syntax_test_data_types.erl
@@ -1,0 +1,243 @@
+-module(syntax_test_data_types).
+
+-compile(export_all).
+
+-spec ascii_numbers() -> ok.
+ascii_numbers() ->
+    $ ,
+    $!, $", $#, $$, $%, $&, $', $(, $), $*, $+, $,, $-, $., $/,
+    $0, $1, $2, $3, $4, $5, $6, $7, $8, $9,
+    $:, $;, $<, $=, $>, $?, $@,
+    $A, $B, $C, $D, $E, $F, $G, $H, $I, $J, $K, $L, $M, $N, $O, $P, $Q, $R, $S, $T, $U, $V, $W, $X, $Y, $Z,
+    $[, $\\, $], $^, $_, $`,
+    $a, $b, $c,$d, $e, $f, $g, $h, $i, $j,  $k, $l, $m, $n, $o, $p, $q, $r, $s, $t, $u, $v, $w, $x, $y, $z,
+    ${, $|,  $}, $~,
+    ok.
+
+-spec integers() -> ok.
+integers() ->
+    42, -1, +1,
+    -1_234_567_890,
+    2#101, 2#1010_1010,
+    8#765, 8#765_432,
+    10#123, 10#123_456,
+    16#1f2E, 16#4865_316F_774F_6C64,
+    36#1234567890abcdefghijklmnopqrstuvwxyz, 36#1234567890ABC_DEF_GHIJ_KLMNOP_QR_STUVWXYZ,
+    ok.
+
+-spec floats() -> ok.
+floats() ->
+    2.3, 2.3e3, 2.3e-3,
+    1_234.333_333,
+    ok.
+
+-spec atoms() -> ok.
+atoms() ->
+    hello, phone_number, 'Monday', 'phone number', bob123@best_place,
+    %% ASCII characters in single quoted atom. Note: the escaped single quote (\') is not in the right position ...
+    ' !"#$%&()*+,-./0123456789:;\'<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
+    %% ... and the reason is that if the escaped single quote followed by an opening parenthesis then it's falsely
+    %% interpreted as a function call
+    'atom\'(A)', %' % TODO: escaped single quote and opening parenthesis ("\'(") shall not break atoms
+    a, 'atom\'(A)',  %' % TODO: -"-
+    ok.
+
+-spec bitstrings_and_binaries() -> ok.
+bitstrings_and_binaries() ->
+    <<10,20>>,
+    <<1:1, 0:1>>,
+    <<$a, $b, $c>>,
+    <<42/integer, 42:16/integer>>,
+    <<2.3/float, 2.3e3:32/float>>,
+    <<"ABC", "ABC"/utf8, "ABC"/utf16, "ABC"/utf32>>,
+    <<$a/utf8, 98/utf16, $c/utf32, 1024/utf8>>,
+    <<2.3/unsigned-big-float>>,
+    <<42:16/signed-little-unit:2-integer>>,
+    <<1:1/binary>>,
+    <<2:2/bytes>>,
+    <<3:3/bitstring>>,
+    <<4:4/bits>>,
+
+    _Bin1 = <<1,17,42>>,
+    _Bin2 = <<"abc">>,
+    _Bin3 = <<1,17,42:16>>,
+    <<_A,_B,_C:16>> = <<1,17,42:16>>,
+    <<_D:16,_E,_F>> = <<1,17,42:16>>,
+    <<G,_H/binary>> = <<1,17,42:16>>,
+    <<G,_J/bitstring>> = <<1,17,42:12>>,
+    ok.
+
+-spec explicit_function_expressions1() -> ok.
+explicit_function_expressions1() ->
+    fun(0) -> 1; (A) -> A+1 end,
+    ok.
+
+-spec explicit_function_expressions2() -> ok.
+explicit_function_expressions2() ->
+    fun (A) when 0/=A -> 1/A;
+        (_) -> 1
+    end,
+    ok.
+
+-spec explicit_function_expressions3() -> ok.
+explicit_function_expressions3() ->
+    fun
+        (A) when 0/=A ->
+            1/A;
+        (_) ->
+            1
+    end,
+    ok.
+
+-spec explicit_function_expressions4() -> ok.
+explicit_function_expressions4() ->
+    fun Fact(1) -> 1; % TODO: Name 'Fact' breaks syntax highlight. See '-define' below.
+        Fact(N) -> N * Fact(N-1)
+    end,
+    ok.
+
+-spec explicit_function_expressions5() -> ok.
+explicit_function_expressions5() ->
+    fun
+        Fact(1) -> % TODO: Name 'Fact' breaks syntax highlight. See '-define' below.
+            1;
+        Fact(N) ->
+            N * Fact(N-1)
+    end,
+    ok.
+
+-define(PLUS_ONE, plus_one).
+-define(ARITY, 1).
+-spec implicit_function_expressions() -> ok.
+implicit_function_expressions() ->
+    %% In Name/Arity, Name is an atom and Arity is an integer.
+    lists:map(fun plus_one/1, [1, 2, 3]),
+    lists:map(fun plus_one/?ARITY, [1, 2, 3]),
+    lists:map(fun ?PLUS_ONE/1, [1, 2, 3]),
+    lists:map(fun ?PLUS_ONE/?ARITY, [1, 2, 3]),
+
+    %% In Module:Name/Arity, Module, and Name are atoms and Arity is an integer.
+    %% Starting from Erlang/OTP R15, Module, Name, and Arity can also be variables.
+    Mod = ?MODULE,
+    Fun = plus_one,
+    Arity = 1,
+    lists:map(fun syntax_test_data_types:plus_one/1, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:plus_one/Arity, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:plus_one/?ARITY, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:Fun/1, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:Fun/Arity, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:Fun/?ARITY, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:?PLUS_ONE/1, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:?PLUS_ONE/Arity, [1, 2, 3]),
+    lists:map(fun syntax_test_data_types:?PLUS_ONE/?ARITY, [1, 2, 3]),
+
+    lists:map(fun Mod:plus_one/1, [1, 2, 3]),
+    lists:map(fun Mod:plus_one/Arity, [1, 2, 3]),
+    lists:map(fun Mod:plus_one/?ARITY, [1, 2, 3]),
+    lists:map(fun Mod:Fun/1, [1, 2, 3]),
+    lists:map(fun Mod:Fun/Arity, [1, 2, 3]),
+    lists:map(fun Mod:Fun/?ARITY, [1, 2, 3]),
+    lists:map(fun Mod:?PLUS_ONE/1, [1, 2, 3]),
+    lists:map(fun Mod:?PLUS_ONE/Arity, [1, 2, 3]),
+    lists:map(fun Mod:?PLUS_ONE/?ARITY, [1, 2, 3]),
+
+    lists:map(fun ?MODULE:plus_one/1, [1, 2, 3]), % TODO: syntax highlight function name
+    lists:map(fun ?MODULE:plus_one/Arity, [1, 2, 3]), % TODO: syntax highlight function name
+    lists:map(fun ?MODULE:plus_one/?ARITY, [1, 2, 3]), % TODO: syntax highlight function name
+    lists:map(fun ?MODULE:Fun/1, [1, 2, 3]),
+    lists:map(fun ?MODULE:Fun/Arity, [1, 2, 3]),
+    lists:map(fun ?MODULE:Fun/?ARITY, [1, 2, 3]),
+    lists:map(fun ?MODULE:?PLUS_ONE/1, [1, 2, 3]),
+    lists:map(fun ?MODULE:?PLUS_ONE/Arity, [1, 2, 3]),
+    lists:map(fun ?MODULE:?PLUS_ONE/?ARITY, [1, 2, 3]),
+    ok.
+
+-spec plus_one(N::integer()) -> ok.
+plus_one(N) ->
+    N + 1.
+
+-spec 'Plus One'(N::integer()) -> ok.
+'Plus One'(N) ->
+    N + 1.
+
+-spec 'Plus \'()ne'(N::integer()) -> ok. %' % TODO: escaped single quote and opening parenthesis ("\'(") shall not break atoms
+'Plus \'()ne'(N) ->
+    N + 1. %'. % TODO: escaped single quote and opening parenthesis ("\'(") shall not break atoms
+
+-spec tuples() -> ok.
+tuples() ->
+    {adam, 24, {july, 29}},
+    ok.
+
+-spec maps() -> ok.
+maps() ->
+    #{},
+    #{name => adam, age => 24, date => {july, 29}},
+    ok.
+
+-spec lists() -> ok.
+lists() ->
+    [a, 2, {c, 4} | []],
+    "string" "42",
+    ok.
+
+-record(rec,
+        {a = 1 :: integer(),    % a
+         b = 1,                 % b
+         c :: integer(),        % c
+         d                      % d
+         %% after last field
+        } % after fields
+       ). % end of record definition
+
+-spec records() -> ok.
+records() ->
+    #rec.a, % a
+    _A = 1,
+    #rec{},
+    _B = 2,
+    #rec{b = "2", % b
+         c = 1 % c
+        }, % b
+    _C = 2,
+    #rec{a = 1, _ = '_'},
+    _E = 4,
+    ok.
+
+-spec booleans() -> ok.
+booleans() ->
+    true or false.
+
+-spec other_language_constants() -> ok.
+other_language_constants() ->
+    undefined,
+    ok.
+
+-spec escape_sequences() -> ok.
+escape_sequences() ->
+    "a\bc\d\e\fghijklm\nopq\r\s\tu\vwxyz",
+    "\^a\^b\^c\^d\^e\^f\^g\^h\^i\^j\^k\^l\^m\^n\^o\^p\^q\^r\^s\^t\^u\^v\^w\^x\^y\^z",
+    "\^A\^B\^C\^D\^E\^F\^G\^H\^I\^J\^K\^L\^M\^N\^O\^P\^Q\^R\^S\^T\^U\^V\^W\^X\^Y\^Z",
+    "a\"b\'c\\d",
+    "n\157p",
+    "j\x6bl\x6Dn",
+
+    'a\bc\d\e\fghijklm\nopq\r\s\tu\vwxyz',
+    '\^a\^b\^c\^d\^e\^f\^g\^h\^i\^j\^k\^l\^m\^n\^o\^p\^q\^r\^s\^t\^u\^v\^w\^x\^y\^z',
+    '\^A\^B\^C\^D\^E\^F\^G\^H\^I\^J\^K\^L\^M\^N\^O\^P\^Q\^R\^S\^T\^U\^V\^W\^X\^Y\^Z',
+    'a\"b\'c\\d',
+    'n\157p',
+    'j\x6bl\x6Dn',
+
+    $ ,
+    $\b, $\d, $\e, $\f, $\n, $\r, $\s, $\t, $\v,
+    $\^a, $\^b, $\^c, $\^d, $\^e, $\^f, $\^g, $\^h, $\^i, $\^j, $\^k, $\^l, $\^m,
+    $\^n, $\^o, $\^p, $\^q, $\^r, $\^s, $\^t, $\^u, $\^v, $\^w, $\^x, $\^y, $\^z,
+    $\^A, $\^B, $\^C, $\^D, $\^E, $\^F, $\^G, $\^H, $\^I, $\^J, $\^K, $\^L, $\^M,
+    $\^N, $\^O, $\^P, $\^Q, $\^R, $\^S, $\^T, $\^U, $\^V, $\^W, $\^X, $\^Y, $\^Z,
+    $\", $\',
+    $\157,
+    $\x6b, $\x6D,
+    ok.
+
+-define(THE_END, ok).

--- a/syntaxes/test/syntax_test_macros.erl
+++ b/syntaxes/test/syntax_test_macros.erl
@@ -1,0 +1,25 @@
+-module(syntax_test_macros).
+
+-compile(export_all).
+
+-define(ONE, 1).
+-define(INC(N), (N+1)).
+-define(ADD(N, M), (N+M)).
+-define(NAME_VALUE(Param), [??Param, Param]).
+
+-spec f() -> ok.
+f() ->
+    ?ONE,
+    ?INC(1),
+    ?ADD(1, 2),
+    ?ADD(   % parameters
+         1, % 1
+         2  % 2
+        ),  % end
+    X = 1,
+    ?NAME_VALUE(X),
+    ok.
+
+-spec g() -> ok.
+g() ->
+    ok.


### PR DESCRIPTION
- '$<space>' is a valid ASCII number
- Escape sequences '\^a'..'\^z' are valid (and same as '\^A'..'\^Z')
- Escape sequence '\xXY' (where XY are hexadecimal digits) is valid
- 'utf8', 'utf16' and 'utf32' are valid type specifiers in binary
- Binary unit type specifier has a mandatory parameters as
  'unit:<pos_integer>' (where <pos_integer> is in range 1..256)
- Single underscore (_) can be inserted between digits as a visual
  separator (since OTP 23)
- Highlight 'true', 'false' and 'undefined' language constants. Well,
  technically 'undefined' is not that but traditionally used like that.