### PR TITLE
Custom behaviours improvement

### DIFF
--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -88,18 +88,13 @@ should_load_behaviour_module(FileSyntaxTree) ->
     end.
 
 load_behaviour_module(BehaviourModule) ->
-    case gen_lsp_doc_server:get_module_file(BehaviourModule) of
+    case gen_lsp_doc_server:get_module_beam(BehaviourModule) of
         undefined -> undefined;
-        SourceFile ->
-        case lists:reverse(filename:split(SourceFile)) of
-            [FilenameErl, "src" | T] ->
-                RootBeamName = filename:join(lists:reverse([filename:rootname(FilenameErl), "ebin" | T])),
-		        case code:load_abs(RootBeamName) of
-		            {module, _} -> BehaviourModule;
-		            _ -> undefined
-		        end;
-	        _ -> undefined
-	    end
+        BeamFile ->
+            case code:load_abs(BeamFile) of
+                {module, _} -> BehaviourModule;
+                _ -> undefined
+            end
     end.
 
 should_load_parse_transform(FileSyntaxTree) ->


### PR DESCRIPTION
If syntax validator needed file with behaviour definition, the file was located using VSC settings for excluding files from search, so the files excluded from search were not used. This is a problem for the common setup when rebar3 build the project. The .beam file with behaviour definition is normally in _build directory, which is normally excluded from search.

The change causes that behaviour modules, if not found with the current code, are searched in excluded directories as well.