### PR TITLE
I made some cool enhancements

### DIFF
--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -293,8 +293,16 @@ element_at_position(CurrentModule, FileSyntaxTree, Line, Column, LineContents) -
                 Column =< EndColumn -> {function_use, CurrentModule, Function, length(Args)};
                 true -> undefined
             end;
-        ({attribute, {L, StartColumn}, export, _Exports}, _) when L =:= Line andalso StartColumn =< Column ->
-            export;
+        ({attribute, {_L, _StartColumn}, export, _Exports}, _) ->
+            find_function_in_export(CurrentModule, LineContents, Column);
+        ({attribute, _, file, {HrlFile, _}}, _) ->
+            BaseName = filename:basename(HrlFile),
+            Case1 = list_to_binary("-include(\"" ++ BaseName ++ "\").\r") == LineContents andalso Column > length("-include(") andalso Column =< length("-include(") + length(BaseName),
+            Case2 = list_to_binary("-include_lib(\"" ++ BaseName ++ "\").\r") == LineContents andalso Column > length("-include_lib(") andalso Column < length("-include_lib(") + length(BaseName),
+            if 
+                Case1; Case2 -> {hrl, HrlFile};
+                true -> undefined
+            end;
         ({call, {_, _}, {remote, {_, _}, {atom, {_, MStartColumn}, Module}, {atom, {L, StartColumn}, Function}}, Args}, _) when L =:= Line andalso MStartColumn =< Column ->
             MEndColumn = MStartColumn + length(atom_to_list(Module)), 
             EndColumn = StartColumn + length(atom_to_list(Module)) + 1 + length(atom_to_list(Function)),
@@ -335,7 +343,7 @@ element_at_position(CurrentModule, FileSyntaxTree, Line, Column, LineContents) -
                 Column =< EndColumn -> {record, Record};
                 true -> find_record_field_use(Record, Fields, Column)
             end;
-        ({record_field, {L, RecordSttartColumn}, _, Record, {atom, {L, FieldStartColumn}, Field}}, _) when L =:= Line andalso RecordSttartColumn =< Column ->
+        ({record_index, {L, RecordSttartColumn}, Record, {atom, {L, FieldStartColumn}, Field}}, _) when L =:= Line andalso RecordSttartColumn =< Column ->
             FieldEndColumn = FieldStartColumn + length(atom_to_list(Field)),
             if
                 Column < FieldStartColumn -> {record, Record};
@@ -348,7 +356,7 @@ element_at_position(CurrentModule, FileSyntaxTree, Line, Column, LineContents) -
     case find_macro_use(LineContents, Column) of
         undefined ->
             case find_in_file_syntax_tree(FileSyntaxTree, Fun) of
-                {export, _File} -> find_function_in_export(CurrentModule, LineContents, Column);
+                {{function_use, _, _, _} = Export, _File} -> Export;
                 {What, _File} -> What
             end;
         MacroUse -> MacroUse
@@ -399,6 +407,8 @@ find_element({module_use, Module}, _CurrentFileSyntaxTree, _CurrentFile) ->
         {attribute, {Line, Column}, _} -> {File, Line, Column};
         _ -> undefined
     end;
+find_element({hrl, HrlFile}, _CurrentFileSyntaxTree, _CurrentFile) ->
+    {HrlFile, 1, 1};
 find_element({function_use, Module, Function, Arity}, _CurrentFileSyntaxTree, _CurrentFile) ->
     {SyntaxTree, File} = lsp_syntax:module_syntax_tree(Module),
     case find_function(SyntaxTree, Function, Arity) of
@@ -530,6 +540,8 @@ find_record(FileSyntaxTree, Record) ->
 find_record_field(_Field, [], _CurrentFile) ->
     undefined;
 find_record_field(Field, [{record_field, _, {atom, {Line, Column}, Field}} | _], CurrentFile) ->
+    {CurrentFile, Line, Column};
+find_record_field(Field, [{record_field, _, {atom, {Line, Column}, Field}, _} | _], CurrentFile) ->
     {CurrentFile, Line, Column};
 find_record_field(Field, [_ | Tail], CurrentFile) ->
     find_record_field(Field, Tail, CurrentFile).

--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -94,9 +94,9 @@ find_macro_definition(_Macro, _File, undefined) ->
     undefined;
 find_macro_definition(_Macro, _File, []) ->
     undefined;
-find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{var, Line, Macro}, _]}} | _]) ->
+find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{_, Line, Macro}, _]}} | _]) ->
     {File, Line, 1};
-find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{_, _, _, {_, {var, Line, Macro}, _}}, _]}} | _]) ->
+find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{_, _, _, {_, {_, Line, Macro}, _}}, _]}} | _]) ->
     {File, Line, 1};
 find_macro_definition(Macro, File, [_ | Tail]) ->
     find_macro_definition(Macro, File, Tail).

--- a/apps/erlangbridge/src/vscode_connection.erl
+++ b/apps/erlangbridge/src/vscode_connection.erl
@@ -101,7 +101,8 @@ decode_request(Data) ->
             Breakpoints),
         #{}; 
     {debugger_eval, Body} ->
-        [PidString, Sp, Expression] = string:tokens(Body, "\r\n"),
+        [PidString, Sp | Expression1] = string:tokens(Body, "\r\n"),
+        Expression = lists:concat(Expression1),
         Bindings = debugger_eval_bindings(PidString, Sp),
         ExpressionWithDot = case Expression =/= [] andalso lists:last(Expression) =:= $. of
             true -> Expression;


### PR DESCRIPTION
## Change log

1. `-include`
    - Change the matching range (this change is of no consequence)
2. `record`
    - Match more cases
3. `module_use` and `function_use`
    - This is a cool enhancement
    - Even if `module` and `function` are in the `Args`, you can still use go to definition
    - It also works when in a tuple
    - Here is an example

---
--> main.erl <--
```erlang
-module(main).
-compile(export_all).

start(RoleId) ->
    %% You could write it like this
    lib_test:apply_cast(mod_test, run, [RoleId])
    %% or like this
    {mod_test, run, [RoleId]},
    %% And even that
    {mod_test, run},
    ok.

    %% go to definition valid for both `mod_test` and `run`
```
---
--> mod_test.erl <--
```erlang
-module(mod_test).
-compile(export_all).

run(RoleId) ->
    ok.
```
