### PR TITLE
Fix and Addition

### DIFF
--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -542,6 +542,8 @@ find_element({variable, Variable, Line, Column}, CurrentFileSyntaxTree, CurrentF
                         _ -> FunClauseAcc
                     end
                 end, SingleAcc, Clauses);
+            {function, _, _, _, ClausesList} ->
+                matched_fun_clause(lists:reverse(ClausesList), Line);
             _ ->
                 SingleAcc
         end
@@ -562,6 +564,10 @@ find_element({macro_use, Macro}, _CurrentFileSyntaxTree, CurrentFile) ->
     lsp_syntax:find_macro_definition(Macro, CurrentFile);
 find_element(_, _CurrentFileSyntaxTree, _CurrentFile) ->
     undefined.
+
+matched_fun_clause([{clause, {ClauseLine, _}, _, _, _} = Clause | _], Line) when ClauseLine =< Line -> [Clause];
+matched_fun_clause([_ | Tail], Line) -> matched_fun_clause(Tail, Line);
+matched_fun_clause([], _line) -> [].
 
 find_function_with_line(FileSyntaxTree, Line) ->
     AllFunctionsInReverseOrder = lists:foldl(fun (TopLevelSyntaxTree, Acc) ->


### PR DESCRIPTION
Make function_use can jump to a more precise location
> `t.erl`
```erlang
-module(t).
-compile(export_all).

-define(GOODS_ID, 3).

start() ->
    data_goods:get(?GOODS_ID),
    ok.

```

> `data_goods.erl`
```erlang
-module(data_goods).
-export([get/1]).

get(1) -> 1001;

get(2) -> 1002;

get(3) -> 1003;

get(4) -> 1004;

get(_) -> 0.

```