### PR TITLE
Fix handling of UNC paths on Windows

### DIFF
--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -264,11 +264,10 @@ request_configuration(Socket) ->
     }).
 
 send_diagnostics(Socket, File, Diagnostics) ->
-    BinFile = list_to_binary(File),
     gen_lsp_server:send_to_client(Socket, #{
         method => <<"textDocument/publishDiagnostics">>,
         params => #{
-            uri => lsp_utils:file_uri_to_vscode_uri(<<"file://", BinFile/binary>>),
+            uri => lsp_utils:file_uri_to_vscode_uri(lsp_utils:file_to_file_uri(File)),
             diagnostics => lists:map(fun (Diagnostic) ->
                 Info = maps:get(info, Diagnostic),
                 #{

--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -20,7 +20,7 @@ goto_definition(File, Line, Column) ->
     case find_element(What, FileSyntaxTree, File) of
         {FoundFile, FoundLine, FoundColumn} ->
             #{
-                uri => lsp_utils:file_uri_to_vscode_uri(list_to_binary("file://" ++ FoundFile)),
+                uri => lsp_utils:file_uri_to_vscode_uri(lsp_utils:file_to_file_uri(FoundFile)),
                 range => lsp_utils:client_range(FoundLine, FoundColumn, FoundColumn)
             };
         _ ->
@@ -113,7 +113,7 @@ references_info(File, Line, Column) ->
         undefined -> #{result => <<"ko">>};
         RefKey -> 
             Result = lists:map(fun ({_, {L,C}}) -> 
-                #{uri => list_to_binary("file://" ++ File), line => L, character => C}
+                #{uri => lsp_utils:file_to_file_uri(File), line => L, character => C}
             end, lists:filter(fun ({K,_L}) -> K =:= RefKey end, References)),
             #{result => <<"ok">>, references => Result}
     end.

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -1,7 +1,7 @@
 -module(lsp_utils).
 
 -export([client_range/3,
-         file_uri_to_file/1, file_uri_to_vscode_uri/1,
+         file_uri_to_file/1, file_uri_to_vscode_uri/1, file_to_file_uri/1,
          glob_to_regexp/1,
          is_path_excluded/2,
          search_exclude_globs_to_regexps/1,
@@ -17,7 +17,8 @@ client_range(Line, StartChar, EndChar) ->
 file_uri_to_file(Uri) ->    
     NewUri = re:replace(case Uri of
         <<"file:///", Drive, "%3A", Rest/binary>> -> <<Drive, ":", Rest/binary>>;
-        <<"file://", Rest/binary>> -> Rest;
+        <<"file:///", Rest/binary>> -> <<"/", Rest/binary>>;
+        <<"file://", Rest/binary>> -> <<"//", Rest/binary>>;
       _ -> Uri
     end, <<"\\\\">>, <<"/">>, [global, {return, list}]),
     lists:flatten(string_replace(NewUri, "%20", " ")).
@@ -32,6 +33,13 @@ file_uri_to_vscode_uri(Uri) ->
         <<"file://", Drive, ":/", Rest/binary>> -> <<"file:///", Drive, "%3A/", Rest/binary>>;
       _ -> EncodeUri
     end.
+
+file_to_file_uri("//" ++ File) ->
+    BinFile = list_to_binary(File),
+    <<"file://", BinFile/binary>>;
+file_to_file_uri(File) ->
+    BinFile = list_to_binary(File),
+    <<"file://", BinFile/binary>>.
 
 -ifdef(OTP_RELEASE).
 string_replace(String, Pattern, NewString) ->


### PR DESCRIPTION
UNC paths on Windows (e.g. \\server\path\to\file.erl) were not handled correctly. `file_uri_to_file` chops off the initial `//` if the file URI is a UNC path. This PR fixes the problem for me. I also had to change the reverse transformation, as it would then add two extra slashes.

Should be tested on Linux.