### PR TITLE
Use single binary closing pair

### DIFF
--- a/erlang.configuration.json
+++ b/erlang.configuration.json
@@ -6,13 +6,13 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["<<", ">>"]
+        ["<", ">"]
     ],
     "autoClosingPairs": [
         { "open": "{", "close": "}", "notIn": ["string", "comment"] },
         { "open": "[", "close": "]", "notIn": ["string", "comment"] },
         { "open": "(", "close": ")", "notIn": ["string", "comment"] },
-        { "open": "<<", "close": ">>", "notIn": ["string", "comment"] },
+        { "open": "<", "close": ">", "notIn": ["string", "comment"] },
         { "open": "'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "\"", "close": "\"" }
     ],


### PR DESCRIPTION
## What does this PR do?

Change to use single `<>` closing pair brackets instead of double `<<>>`.

## Motivation

The motivation for this is an issue when surrounding any value with binary symbols makes the symbols override the value. See:

![erlang_ls_issue](https://user-images.githubusercontent.com/35941533/174415370-cf880048-c367-4c40-8d19-0e33070f6b76.gif)

## Solution

This PR fixes this issue.

![erlang_ls_issue_ok](https://user-images.githubusercontent.com/35941533/174415387-e8d85f4b-413e-48c4-9fe2-d93fa6548805.gif)