### PR TITLE
Back to double binary closing pairs

### DIFF
--- a/erlang.configuration.json
+++ b/erlang.configuration.json
@@ -6,13 +6,13 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["<", ">"]
+        ["<<", ">>"]
     ],
     "autoClosingPairs": [
         { "open": "{", "close": "}", "notIn": ["string", "comment"] },
         { "open": "[", "close": "]", "notIn": ["string", "comment"] },
         { "open": "(", "close": ")", "notIn": ["string", "comment"] },
-        { "open": "<", "close": ">", "notIn": ["string", "comment"] },
+        { "open": "<<", "close": ">>", "notIn": ["string", "comment"] },
         { "open": "'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "\"", "close": "\"" }
     ],


### PR DESCRIPTION
This change removes the change described in PR #232. #232 was fixing the genuine problem: what happens when you want to surround a value with binary brackets. This is a genuine use case however bad side effects of this change are more common and visible:

- typing < character in order to get less-than operator ends up with having two characters <>. Comparison operator is one of the basic Erlang operators and we should be able to type it in without need to delete anything
- the very visible effect of syntax highlighting of the arrow -> 
![image](https://user-images.githubusercontent.com/36209286/223719471-048372dd-4616-4f89-9eaa-25c5034d1a50.png)
EVERY arrow in the Erlang source is marked as a red erroneous closing bracket without the opening one! This makes Erlang source full of red -> arrows.

Let's revert #232, and possibly find some other way to fix the problem described there.
