### PR TITLE
Navigation improvements

### DIFF
--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -31,7 +31,7 @@ parse_document(File) ->
         ".erl" ->
             case get_document_contents(File) of
                 undefined ->
-                    ok;
+                    io:format("Cannot find contents of document ~p~n", [File]);
                 Contents ->
                     ContentsFile = lsp_utils:make_temporary_file(Contents),
                     parse_and_store_trees(File, ContentsFile),

--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -241,7 +241,7 @@ parse_and_store(File, ContentsFile) ->
             ets:delete(references, File),
             lsp_navigation:fold_references(fun (Reference, Line, Column, End, _) ->
                 ets:insert(references, {File, Reference, Line, Column, End})
-            end, undefined, SyntaxTree)
+            end, undefined, File, SyntaxTree)
     end,
     case DodgedSyntaxTree of
         undefined -> ok;

--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -36,7 +36,7 @@ parse_document(File) ->
         ".erl" ->
             case get_document_contents(File) of
                 undefined ->
-                    io:format("Cannot find contents of document ~p~n", [File]);
+                    error_logger:error_msg("Cannot find contents of document ~p~n", [File]);
                 Contents ->
                     ContentsFile = lsp_utils:make_temporary_file(Contents),
                     parse_and_store(File, ContentsFile),

--- a/apps/erlangbridge/src/lsp_completion.erl
+++ b/apps/erlangbridge/src/lsp_completion.erl
@@ -77,24 +77,12 @@ record(File, Prefix) ->
     end, gen_lsp_doc_server:get_syntax_tree(File)).
 
 field(File, Record, Prefix) ->
-    RecordTree = lsp_navigation:find_record(gen_lsp_doc_server:get_syntax_tree(File), Record),
-    case RecordTree of
-        {{attribute, _, record, {Record, Fields}}, _File} ->
-            lists:filtermap(fun 
-                ({record_field, _, {atom, _, Field}}) ->
-                    case lists:prefix(Prefix, atom_to_list(Field)) of
-                        true -> {true, #{
-                            label => list_to_binary(atom_to_list(Field)),
-                            kind => 5 % Field
-                        }};
-                        _ -> false
-                    end;
-                (_) ->
-                    false
-            end, Fields);
-        _ ->
-            []
-    end.
+    lists:filtermap(fun (Field) ->
+        case lists:prefix(Prefix, atom_to_list(Field)) of
+            true -> {true, #{label => list_to_binary(atom_to_list(Field)), kind => 5}};
+            _ -> false
+        end
+    end, lsp_navigation:record_fields(File, Record)).
 
 variable(File, Line, Prefix) ->
     FileSyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),

--- a/apps/erlangbridge/src/lsp_completion.erl
+++ b/apps/erlangbridge/src/lsp_completion.erl
@@ -8,7 +8,7 @@ disable_completion() ->
     }].
 
 module_function(Module, Prefix) ->
-    SyntaxTreeFile = lsp_syntax:module_syntax_tree(Module),
+    SyntaxTreeFile = lsp_parse:module_syntax_tree(Module),
     ExportsResult = case SyntaxTreeFile of
         undefined ->
             standard_module_exports(Module);
@@ -74,10 +74,10 @@ record(File, Prefix) ->
             end;
         (_) ->
             false
-    end, lsp_syntax:file_syntax_tree(File)).
+    end, lsp_parse:file_syntax_tree(File)).
 
 field(File, Record, Prefix) ->
-    RecordTree = lsp_navigation:find_record(lsp_syntax:file_syntax_tree(File), Record),
+    RecordTree = lsp_navigation:find_record(lsp_parse:file_syntax_tree(File), Record),
     case RecordTree of
         {{attribute, _, record, {Record, Fields}}, _File} ->
             lists:filtermap(fun 
@@ -97,7 +97,7 @@ field(File, Record, Prefix) ->
     end.
 
 variable(File, Line, Prefix) ->
-    FileSyntaxTree = lsp_syntax:file_syntax_tree(File),
+    FileSyntaxTree = lsp_parse:file_syntax_tree(File),
     Function = lsp_navigation:find_function_with_line(FileSyntaxTree, Line),
     case Function of
         undefined ->
@@ -157,7 +157,7 @@ atom(File, Prefix) ->
     LocalAtoms ++ StandardModules ++ ProjectModules ++ BIFs.
 
 local_atoms(File) ->
-    FileSyntaxTree = lsp_syntax:file_syntax_tree(File),
+    FileSyntaxTree = lsp_parse:file_syntax_tree(File),
     AtomTypes = lists:foldl(fun (TopLevelSyntaxTree, Acc) ->
         erl_syntax_lib:fold(fun (SyntaxTree, AccS) ->
             case SyntaxTree of

--- a/apps/erlangbridge/src/lsp_completion.erl
+++ b/apps/erlangbridge/src/lsp_completion.erl
@@ -8,11 +8,11 @@ disable_completion() ->
     }].
 
 module_function(Module, Prefix) ->
-    SyntaxTreeFile = lsp_parse:module_syntax_tree(Module),
-    ExportsResult = case SyntaxTreeFile of
+    File = gen_lsp_doc_server:get_module_file(Module),
+    ExportsResult = case gen_lsp_doc_server:get_document_syntax_tree(File) of
         undefined ->
             standard_module_exports(Module);
-        {SyntaxTree, _File} ->
+        SyntaxTree ->
             syntax_tree_exports(SyntaxTree)
     end,
     case ExportsResult of
@@ -74,10 +74,10 @@ record(File, Prefix) ->
             end;
         (_) ->
             false
-    end, lsp_parse:file_syntax_tree(File)).
+    end, gen_lsp_doc_server:get_document_syntax_tree(File)).
 
 field(File, Record, Prefix) ->
-    RecordTree = lsp_navigation:find_record(lsp_parse:file_syntax_tree(File), Record),
+    RecordTree = lsp_navigation:find_record(gen_lsp_doc_server:get_document_syntax_tree(File), Record),
     case RecordTree of
         {{attribute, _, record, {Record, Fields}}, _File} ->
             lists:filtermap(fun 
@@ -97,7 +97,7 @@ field(File, Record, Prefix) ->
     end.
 
 variable(File, Line, Prefix) ->
-    FileSyntaxTree = lsp_parse:file_syntax_tree(File),
+    FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
     Function = lsp_navigation:find_function_with_line(FileSyntaxTree, Line),
     case Function of
         undefined ->
@@ -157,7 +157,7 @@ atom(File, Prefix) ->
     LocalAtoms ++ StandardModules ++ ProjectModules ++ BIFs.
 
 local_atoms(File) ->
-    FileSyntaxTree = lsp_parse:file_syntax_tree(File),
+    FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
     AtomTypes = lists:foldl(fun (TopLevelSyntaxTree, Acc) ->
         erl_syntax_lib:fold(fun (SyntaxTree, AccS) ->
             case SyntaxTree of

--- a/apps/erlangbridge/src/lsp_completion.erl
+++ b/apps/erlangbridge/src/lsp_completion.erl
@@ -9,7 +9,7 @@ disable_completion() ->
 
 module_function(Module, Prefix) ->
     File = gen_lsp_doc_server:get_module_file(Module),
-    ExportsResult = case gen_lsp_doc_server:get_document_syntax_tree(File) of
+    ExportsResult = case gen_lsp_doc_server:get_syntax_tree(File) of
         undefined ->
             standard_module_exports(Module);
         SyntaxTree ->
@@ -74,10 +74,10 @@ record(File, Prefix) ->
             end;
         (_) ->
             false
-    end, gen_lsp_doc_server:get_document_syntax_tree(File)).
+    end, gen_lsp_doc_server:get_syntax_tree(File)).
 
 field(File, Record, Prefix) ->
-    RecordTree = lsp_navigation:find_record(gen_lsp_doc_server:get_document_syntax_tree(File), Record),
+    RecordTree = lsp_navigation:find_record(gen_lsp_doc_server:get_syntax_tree(File), Record),
     case RecordTree of
         {{attribute, _, record, {Record, Fields}}, _File} ->
             lists:filtermap(fun 
@@ -97,7 +97,7 @@ field(File, Record, Prefix) ->
     end.
 
 variable(File, Line, Prefix) ->
-    FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
+    FileSyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
     Function = lsp_navigation:find_function_with_line(FileSyntaxTree, Line),
     case Function of
         undefined ->
@@ -157,7 +157,7 @@ atom(File, Prefix) ->
     LocalAtoms ++ StandardModules ++ ProjectModules ++ BIFs.
 
 local_atoms(File) ->
-    FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
+    FileSyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
     AtomTypes = lists:foldl(fun (TopLevelSyntaxTree, Acc) ->
         erl_syntax_lib:fold(fun (SyntaxTree, AccS) ->
             case SyntaxTree of

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -63,11 +63,11 @@ workspace_didChangeConfiguration(Socket, _Params) ->
 workspace_didChangeWatchedFiles(_Socket, Params) ->
     lists:foreach(fun
         (#{uri := Uri, type := 1}) -> % Created 
-            gen_lsp_doc_server:add_project_file(lsp_utils:file_uri_to_file(Uri));
-        (#{uri := _Uri, type := 2}) -> % Changed  
-            nothing;
+            gen_lsp_doc_server:project_file_added(lsp_utils:file_uri_to_file(Uri));
+        (#{uri := Uri, type := 2}) -> % Changed  
+            gen_lsp_doc_server:project_file_changed(lsp_utils:file_uri_to_file(Uri));
         (#{uri := Uri, type := 3}) -> % Deleted  
-            gen_lsp_doc_server:remove_project_file(lsp_utils:file_uri_to_file(Uri))
+            gen_lsp_doc_server:project_file_deleted(lsp_utils:file_uri_to_file(Uri))
     end, maps:get(changes, Params)).
 
 textDocument_didOpen(Socket, Params) ->

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -223,7 +223,7 @@ file_contents_update(Socket, File, Contents) ->
     end,
     case filename:extension(File) of
         ".erl" ->
-            lsp_syntax:parse_source_file(File, ContentsFile),
+            lsp_parse:parse_source_file(File, ContentsFile),
             Linting andalso validate_parsed_source_file(Socket, File);
         ".src" ->
             Linting andalso validate_config_file(Socket, File, ContentsFile);
@@ -239,7 +239,7 @@ validate_parsed_source_file(Socket, File) ->
     send_diagnostics(Socket, File, maps:get(errors_warnings, ErrorsWarnings, [])).
 
 validate_config_file(Socket, File, ContentsFile) ->
-    ErrorsWarnings = lsp_syntax:parse_config_file(File, ContentsFile),
+    ErrorsWarnings = lsp_parse:parse_config_file(File, ContentsFile),
     send_diagnostics(Socket, File, maps:get(errors_warnings, ErrorsWarnings, [])).
 
 -ifdef(OTP_RELEASE).

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -205,8 +205,16 @@ textDocument_codeLens(_Socket, Params) ->
 
 textDocument_documentSymbol(_Socket, Params) ->
     Uri = mapmapget(textDocument, uri, Params),
-    lsp_navigation:symbol_info(Uri, lsp_utils:file_uri_to_file(Uri)).
-    %test_symbols(Uri, 25).
+    lists:map(fun ({Name, Kind, Line}) ->
+        #{
+            name => Name,
+            kind => Kind, 
+            location => #{ 
+                uri => Uri, 
+                range => lsp_utils:client_range(Line, 1, 1)
+            }
+        }
+    end, lsp_navigation:symbol_info(lsp_utils:file_uri_to_file(Uri))).
 
 validate_file(Socket, File) ->
     case gen_lsp_config_server:linting() of

--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -13,7 +13,7 @@
 	end).
 
 goto_definition(File, Line, Column) ->
-    FileSyntaxTree = lsp_syntax:file_syntax_tree(File),
+    FileSyntaxTree = lsp_parse:file_syntax_tree(File),
     Module = list_to_atom(filename:rootname(filename:basename(File))),
     What = element_at_position(Module, FileSyntaxTree, Line, Column, file_line(File, Line)),
     ?LOG("element_at_position : ~p", [What]),
@@ -44,7 +44,7 @@ file_line(File, Line) ->
 
 hover_info(File, Line, Column) ->
     Module = list_to_atom(filename:rootname(filename:basename(File))),
-    FileSyntax = lsp_syntax:file_syntax_tree(File),
+    FileSyntax = lsp_parse:file_syntax_tree(File),
     What = element_at_position(Module, FileSyntax, Line, Column, file_line(File, Line)),
     %gen_lsp_server:lsp_log("hover_info What:~p", [What]),
     case What of
@@ -69,7 +69,7 @@ function_description(Module, Function) ->
     end.
 
 function_description(Module, Function, Arity) ->
-    SyntaxTreeFile = lsp_syntax:module_syntax_tree(Module),                    
+    SyntaxTreeFile = lsp_parse:module_syntax_tree(Module),                    
     case SyntaxTreeFile of
         {SyntaxTree, File} ->
             case lsp_utils:is_erlang_lib_file(File) of
@@ -107,7 +107,7 @@ get_generic_help(Module, Function) ->
 
 references_info(File, Line, Column) ->
     MapResult = fold_in_file_syntax_tree(
-        lsp_syntax:file_syntax_tree(File), 
+        lsp_parse:file_syntax_tree(File), 
         #{location => {Line, Column}, references => []}, 
         fun references_analyze/2),
     References = maps:get(references, MapResult),
@@ -142,7 +142,7 @@ references_analyze(SyntaxTree, Map) ->
 codelens_info(File) ->
     %filter only defined functions
     MapResult = maps:filter(fun (_K,V) -> maps:is_key(func_name, V) end,
-        fold_in_file_syntax_tree(lsp_syntax:file_syntax_tree(File), #{}, fun codelens_analyze/2)),
+        fold_in_file_syntax_tree(lsp_parse:file_syntax_tree(File), #{}, fun codelens_analyze/2)),
     lists:filtermap(fun (V) ->
         case maps:get(location, V, undefined) of
             {Line, Column} ->
@@ -207,7 +207,7 @@ codelens_add_or_update_refcount(Map, Key, Count) ->
 
 symbol_info(Uri, File) ->
     %return all symbols for the specified document 
-    SyntaxTree = lsp_syntax:file_syntax_tree(File),
+    SyntaxTree = lsp_parse:file_syntax_tree(File),
     %gen_lsp_server:lsp_log("syntax for symbolinfo : ~p", [SyntaxTree]),
     fold_in_file_syntax_tree(SyntaxTree, [], fun (S, Acc) -> symbolinfo_analyze(Uri, S, Acc) end).
 
@@ -431,7 +431,7 @@ process_hrl_filename(File, LineContents, Column) ->
     end.
 
 resolve_include_file_path(File, IncludeFileName) ->
-    IncludePaths = lsp_syntax:get_include_path(File),
+    IncludePaths = lsp_parse:get_include_path(File),
     Candidates = [filename:join(Path, IncludeFileName) || Path <- IncludePaths],
     case lists:filter(fun filelib:is_file/1, Candidates) of
         [First|_] -> First;
@@ -550,7 +550,7 @@ find_record_field_use(Record, [_Head | Tail], Column, Line) ->
     find_record_field_use(Record, Tail, Column, Line).
 
 find_element({module_use, Module}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    case lsp_syntax:module_syntax_tree(Module) of
+    case lsp_parse:module_syntax_tree(Module) of
         undefined -> undefined;
         {SyntaxTree, File} ->
             case find_module(SyntaxTree, Module) of
@@ -561,7 +561,7 @@ find_element({module_use, Module}, _CurrentFileSyntaxTree, _CurrentFile) ->
 find_element({hrl, HrlFile}, _CurrentFileSyntaxTree, _CurrentFile) ->
     {HrlFile, 1, 1};
 find_element({function_use, Module, Function, Arity}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    case lsp_syntax:module_syntax_tree(Module) of
+    case lsp_parse:module_syntax_tree(Module) of
         undefined -> undefined;
         {SyntaxTree, File} ->
             case find_function(SyntaxTree, Function, Arity) of
@@ -570,7 +570,7 @@ find_element({function_use, Module, Function, Arity}, _CurrentFileSyntaxTree, _C
             end
     end;
 find_element({function_use, Module, Function, Arity, Args}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    case lsp_syntax:module_syntax_tree(Module) of
+    case lsp_parse:module_syntax_tree(Module) of
         undefined -> undefined;
         {SyntaxTree, File} ->
             case find_function(SyntaxTree, Function, Arity) of
@@ -705,7 +705,7 @@ variable_in_fun_clause_arguments(Variable, {clause, {_, _}, Arguments, _, _}) ->
     length(find_variable_occurrences(Variable, Arguments)) > 0.
 
 get_function_arities(Module, Function) ->
-    case lsp_syntax:module_syntax_tree(Module) of
+    case lsp_parse:module_syntax_tree(Module) of
         {FileSyntaxTree, _File} ->
             lists:sort(fold_in_file_syntax_tree(FileSyntaxTree, [], fun
                 ({function, _Position, FoundFunction, Arity, _Clauses}, Acc) when FoundFunction =:= Function ->

--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -28,7 +28,7 @@ goto_definition(File, Line, Column) ->
     end.
 
 file_line(File, Line) ->
-    Contents = case gen_lsp_doc_server:get_document_attribute(File, contents) of
+    Contents = case gen_lsp_doc_server:get_document_contents(File) of
         undefined ->
             {ok, FileContents} = file:read_file(File),
             FileContents;

--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -1,7 +1,7 @@
 -module(lsp_navigation).
 
--export([definition/3, hover_info/3, function_description/2, function_description/3, references/3, codelens_info/1,
-    find_function_with_line/2, get_function_arities/2, find_record/2, symbol_info/2, fold_references/3]).
+-export([definition/3, hover_info/3, function_description/2, function_description/3, references/3]).
+-export([codelens_info/1, symbol_info/1, find_function_with_line/2, get_function_arities/2, find_record/2, fold_references/3]).
 
 -define(LOG(S),
 	begin
@@ -58,6 +58,32 @@ codelens_info(File) ->
             length(gen_lsp_doc_server:get_references({function, FileModule, Function, Arity})),
         {Function, RefCount, maps:is_key({Function, Arity}, Exports), L, Start}
     end, Functions).
+
+symbol_info(File) ->
+    lists:reverse(fold_in_syntax_tree(fun
+        (_SyntaxTree, CurrentFile, Acc) when CurrentFile =/= File ->
+            Acc;
+        ({function, {L, _}, Function, Arity, _}, _CurrentFile, Acc) ->
+            FullName = iolist_to_binary(io_lib:format("~p/~p", [Function, Arity])),
+            [{FullName, 12, L} | Acc];
+        ({attribute, {L, _}, record, {Record, _}}, _CurrentFile, Acc) ->
+            [{Record, 23, L} | Acc];
+        (_SyntaxTree, _CurrentFile, Acc) ->
+            Acc
+    end, [], File, gen_lsp_doc_server:get_syntax_tree(File))).
+
+create_symbolinfo(FuncName, Uri, SymbolKind, {L, C}) ->
+    #{
+        name => FuncName,
+        kind => SymbolKind, 
+        location => #{ 
+            uri => Uri, 
+            range => #{ 
+                start => #{ character => C, line => L-1}, 
+                <<"end">> => #{ character => C, line => L-1 } 
+            } 
+        }
+    }.
 
 find_at(File, Line, Column) ->
     FileModule = list_to_atom(filename:rootname(filename:basename(File))),
@@ -488,66 +514,6 @@ get_generic_help(Module, Function) ->
         undefined -> <<>>;
         _ -> Help
     end.
-
-symbol_info(Uri, File) ->
-    %return all symbols for the specified document 
-    SyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
-    %gen_lsp_server:lsp_log("syntax for symbolinfo : ~p", [SyntaxTree]),
-    fold_in_syntax_tree(fun (S, Acc) -> symbolinfo_analyze(Uri, S, Acc) end, [], SyntaxTree).
-
-symbolinfo_analyze(Uri, SyntaxTree, List) ->
-    case SyntaxTree of
-    {function, Location, FuncName, Arity, _} -> 
-        FuncFullName = list_to_binary(lists:flatten(io_lib:format("~p/~p", [FuncName,Arity]))),
-        List++ create_symbolinfo(FuncFullName, Uri, function, Location);
-    {attribute, Location, record, {Record, _}} ->
-        List++ create_symbolinfo(Record, Uri, struct, Location);
-    {attribute, Location, type, {Type, _, _}} ->
-        List++ create_symbolinfo(Type, Uri, class, Location);
-    _ -> List
-    end.
-
-symbol_kind(ErlangKind) ->
-    %mapping a name to number expected by vscode
-    case ErlangKind of 
-    function -> 9;
-    interface -> 11;
-    array -> 18;
-    namespace -> 19;
-    event -> 24;
-    string -> 15;
-    struct -> 23;
-    number -> 16;
-    null -> 21;
-    constant -> 14;
-    class -> 5;
-    boolean -> 17;
-    _ -> 1
-    end.
-
-symbol_container_from_symbol_kind(ErlangKind) ->
-    case ErlangKind of
-    function -> <<"functions">>;
-    class -> <<"types">>;
-    struct -> <<"records">>;
-    _ -> <<"root">>
-    end.
-
-create_symbolinfo(FuncName, Uri, SymbolKind, {L, C}) ->
-    %gen_lsp_server:lsp_log("create symbol info, ~p: ~p", [FuncName, Location]),
-    %vscode documentation  : https://code.visualstudio.com/docs/extensionAPI/vscode-api#SymbolInformation
-    [#{
-        containerName => symbol_container_from_symbol_kind(SymbolKind),
-        name => FuncName,
-        kind => symbol_kind(SymbolKind), 
-        location => #{ 
-            uri => Uri, 
-            range => #{ 
-                start => #{ character => C, line => L-1}, 
-                <<"end">> => #{ character => C, line => L-1 } 
-            } 
-        }
-    }].
 
 function_header(Function, Args) ->
     "**" ++ atom_to_list(Function) ++ "**(" ++ join_strings(lists:map(fun erl_prettypr:format/1, Args), ", ") ++ ")".

--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -1,7 +1,7 @@
 -module(lsp_navigation).
 
--export([goto_definition/3, hover_info/3, function_description/2, function_description/3, references_info/3, codelens_info/1,
-    find_function_with_line/2, get_function_arities/2, find_record/2, symbol_info/2]).
+-export([definition/3, hover_info/3, function_description/2, function_description/3, references/3, codelens_info/1,
+    find_function_with_line/2, get_function_arities/2, find_record/2, symbol_info/2, fold_references/3]).
 
 -define(LOG(S),
 	begin
@@ -12,20 +12,413 @@
         gen_lsp_server:lsp_log(Fmt, Args)
 	end).
 
-goto_definition(File, Line, Column) ->
-    FileSyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
-    Module = list_to_atom(filename:rootname(filename:basename(File))),
-    What = element_at_position(Module, FileSyntaxTree, Line, Column, file_line(File, Line)),
-    ?LOG("element_at_position : ~p", [What]),
-    case find_element(What, FileSyntaxTree, File) of
-        {FoundFile, FoundLine, FoundColumn} ->
-            #{
-                uri => lsp_utils:file_uri_to_vscode_uri(lsp_utils:file_to_file_uri(FoundFile)),
-                range => lsp_utils:client_range(FoundLine, FoundColumn, FoundColumn)
-            };
+definition(File, Line, Column) ->
+    find_definition(File, find_at(File, Line, Column)).
+
+hover_info(File, Line, Column) ->
+    case find_at(File, Line, Column) of
+        {reference, {function, Module, Function, Arity}} ->
+            function_description(Module, Function, Arity);
         _ ->
-            throw(<<"Definition not found">>)
+            undefined
     end.
+
+references(File, Line, Column) ->
+    FileModule = list_to_atom(filename:rootname(filename:basename(File))),
+    case find_at(File, Line, Column) of
+        {_, {function, Module, Function, Arity}} ->
+            Local = case FileModule =:= Module of
+                true -> local_function_references(File, Function, Arity);
+                false -> []
+            end,
+            Global = [{F, L, C, E} || [F, L, C, E] <- gen_lsp_doc_server:get_references({function, Module, Function, Arity})],
+            Global ++ Local;
+        {variable, {Variable, VariableLine, VariableColumn}} ->
+            Length = length(atom_to_list(Variable)),
+            [{File, L, C, C + Length} || {L, C} <- variable_references(File, Variable, VariableLine, VariableColumn)];
+        _ ->
+            []
+    end.
+
+codelens_info(File) ->
+    {Functions, Exports} = fold_in_syntax_tree(fun
+        ({function, {L, Start}, Function, Arity, _}, CurrentFile, {FunAcc, ExportAcc}) when CurrentFile =:= File ->
+            {[{Function, Arity, L, Start} | FunAcc], ExportAcc};
+        ({attribute,_, export, Exports}, _CurrentFile, {FunAcc, ExportAcc}) ->
+            UpdatedExportAcc = lists:foldl(fun ({Function, Arity}, Acc) ->
+                Acc#{{Function, Arity} => true}
+            end, ExportAcc, Exports),
+            {FunAcc, UpdatedExportAcc};
+        (_SyntaxTree, _CurrentFile, Acc) ->
+            Acc
+    end, {[], #{}}, File, gen_lsp_doc_server:get_syntax_tree(File)),
+    FileModule = list_to_atom(filename:rootname(filename:basename(File))),
+    lists:map(fun ({Function, Arity, L, Start}) ->
+        RefCount = length(local_function_references(File, Function, Arity)) +
+            length(gen_lsp_doc_server:get_references({function, FileModule, Function, Arity})),
+        {Function, RefCount, maps:is_key({Function, Arity}, Exports), L, Start}
+    end, Functions).
+
+find_at(File, Line, Column) ->
+    FileModule = list_to_atom(filename:rootname(filename:basename(File))),
+    LineContents = file_line(File, Line),
+    case find_with_re(File, LineContents, Column) of
+        undefined ->
+            find_in_syntax_tree(fun
+                (_SyntaxTree, CurrentFile) when CurrentFile =/= File ->
+                    undefined;
+                ({call, {L, Start}, {atom, {L, Start}, Function}, Args}, _CurrentFile) when L == Line, Column >= Start ->
+                    End = Start + length(atom_to_list(Function)),
+                    if
+                        Column =< End -> {reference, {function, FileModule, Function, length(Args)}};
+                        true -> undefined
+                    end;
+                ({attribute, {_L, _StartColumn}, export, _Exports}, _CurrentFile) ->
+                    find_exported_function(FileModule, LineContents, Column);
+                ({call, {_, _}, {remote, {_, _}, {atom, {_, ModuleStart}, Module}, {atom, {L, Start}, Function} = Prefix}, Args}, _CurrentFile) ->
+                    ModuleEnd = ModuleStart + length(atom_to_list(Module)), 
+                    End = Start + length(atom_to_list(Function)),
+                    if
+                        L == Line, ModuleStart =< Column, Column =< ModuleEnd -> {reference, {module, Module}};
+                        L == Line, Start =< Column, Column =< End -> {reference, {function, Module, Function, length(Args)}};
+                        true -> find_gen_msg(Module, Function, Prefix, Args, Line, Column)
+                    end;
+                ({'fun',{L, Start}, {function, Function, Arity}}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + 4 + length(atom_to_list(Function)),
+                    if
+                        Column =< End -> {reference, {function, FileModule, Function, Arity}};
+                        true -> undefined
+                    end;
+                ({'fun', {_, _}, {function, {atom, {_, _}, Module}, {atom, {L, Start}, Function}, {integer, {_, _}, Arity}}}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + length(atom_to_list(Function)),
+                    if
+                        Column =< End -> {reference, {function, Module, Function, Arity}};
+                        true -> undefined
+                    end;
+                ({var, {L, Start}, Variable}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + length(atom_to_list(Variable)),
+                    if
+                        Column =< End -> {variable, {Variable, L, Start}};
+                        true -> undefined
+                    end;
+                ({record, {L, Start}, Record, Fields}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + length(atom_to_list(Record)),
+                    if
+                        Column =< End -> {reference, {record, Record}};
+                        true -> find_record_field(Record, Fields, Column, Line)
+                    end;
+                ({record, _, Record, Fields}, _CurrentFile) ->
+                    find_record_field(Record, Fields, Column, Line);
+                ({record, {L, Start}, _, Record, Fields}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + length(atom_to_list(Record)),
+                    if
+                        Column =< End -> {reference, {record, Record}};
+                        true -> find_record_field(Record, Fields, Column, Line)
+                    end;
+                ({record, _, _, Record, Fields}, _CurrentFile) ->
+                    find_record_field(Record, Fields, Column, Line);
+                ({record_field, _, _, Record, {atom, {L, Start}, Field}}, _CurrentFile) when L == Line, Start =< Column ->
+                    End = Start + length(atom_to_list(Field)),
+                    if
+                        Column =< End -> {reference, {field, Record, Field}};
+                        true -> undefined
+                    end;
+                ({record_index, {L, RecordStart}, Record, {atom, {L, Start}, Field}}, _CurrentFile) when L == Line, RecordStart =< Column ->
+                    End = Start + length(atom_to_list(Field)),
+                    if
+                        Column < Start -> {reference, {record, Record}};
+                        Column =< End -> {reference, {field, Record, Field}};
+                        true -> undefined
+                    end;
+                ({function, {L, Start}, Function, Arity, _}, _CurrentFile) when L =:= Line andalso Start =< Column ->
+                    End = Start + length(atom_to_list(Function)),
+                    if
+                        Column < End -> {definition, {function, FileModule, Function, Arity}};
+                        true -> undefined
+                    end;
+                (_SyntaxTree, _CurrentFile) ->
+                    undefined
+            end, File);
+        FoundWithRE ->
+            FoundWithRE
+    end.
+
+fold_in_syntax_tree(_Fun, StartAcc, _File, undefined) ->
+    StartAcc;
+fold_in_syntax_tree(Fun, StartAcc, File, SyntaxTree) ->
+    {Result, _, _} = lists:foldl(fun (TopLevelElementSyntaxTree, Acc) ->
+        erl_syntax_lib:fold(fun
+            ({attribute, _, file, {NewFile, _}} = Tree, {ValueAcc, _CurrentFile, undefined}) ->
+                {Fun(Tree, File, ValueAcc), File, NewFile};
+            ({attribute, _, file, {NewFile, _}} = Tree, {ValueAcc, _CurrentFile, FirstFile}) when NewFile =:= FirstFile ->
+                {Fun(Tree, File, ValueAcc), File, FirstFile};
+            ({attribute, _, file, {NewFile, _}} = Tree, {ValueAcc, _CurrentFile, FirstFile}) ->
+                {Fun(Tree, NewFile, ValueAcc), NewFile, FirstFile};
+            (Tree, {ValueAcc, CurrentFile, FirstFile}) ->
+                {Fun(Tree, CurrentFile, ValueAcc), CurrentFile, FirstFile}
+        end, Acc, TopLevelElementSyntaxTree)
+    end, {StartAcc, File, undefined}, SyntaxTree),
+    Result.
+
+fold_in_syntax_tree(_Fun, StartAcc, undefined) ->
+    StartAcc;
+fold_in_syntax_tree(Fun, StartAcc, SyntaxTree) ->
+    lists:foldl(fun (TopLevelSyntaxTree, Acc) ->
+        erl_syntax_lib:fold(Fun, Acc, TopLevelSyntaxTree)
+    end, StartAcc, SyntaxTree).
+
+find_in_syntax_tree(Fun, File) ->
+    fold_in_syntax_tree(fun
+        (SyntaxTree, CurrentFile, undefined) -> Fun(SyntaxTree, CurrentFile);
+        (_SyntaxTree, _CurrentFile, Value) -> Value
+    end, undefined, File, gen_lsp_doc_server:get_syntax_tree(File)).
+
+find_exported_function(_CurrentModule, undefined, _Column) ->
+    undefined;
+find_exported_function(CurrentModule, LineContents, Column) ->
+    case re:run(LineContents, <<"([a-z][A-Z_0-9a-z@]*)/([0-9]+)">>, [global]) of
+        {match, Matches} ->
+            case lists:filter(fun ([{Pos, Len}, _, _]) -> Column > Pos andalso Column =< Pos + Len end, Matches) of
+                [[_, {NamePos, NameLen}, {ArityPos, ArityLen}]] ->
+                    Function = binary_to_atom(binary:part(LineContents, NamePos, NameLen), latin1),
+                    Arity = binary_to_integer(binary:part(LineContents, ArityPos, ArityLen)),
+                    {reference, {function, CurrentModule, Function, Arity}};
+                _ -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+find_gen_msg(Module, Function, Prefix, Args, Line, Column) ->
+    GenFun = fun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg) ->
+        GEndColumn = GenMsgColumn + length(atom_to_list(AtomMsg)),
+        case Line == GenMsgLine andalso GenMsgColumn =< Column andalso Column =< GEndColumn of
+            true when Module =:= gen_server ->
+                {gen_msg, [GenMsg]};
+            true when Module =:= gen_statem ->
+                PreMsg = case Function of
+                    call -> {tuple, {0, 0}, [Prefix, {var, {0, 0}, 'From'}]};
+                    _ -> Prefix
+                end,
+                {gen_msg, [PreMsg, GenMsg]};
+            _ ->
+                undefined
+        end
+    end,
+    case Args of
+        [_, {atom, {GenMsgLine, GenMsgColumn}, AtomMsg} = GenMsg | _] ->
+            GenFun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg);
+        [_, {tuple, _, [{atom, {GenMsgLine, GenMsgColumn}, AtomMsg} | _]} = GenMsg | _] ->
+            GenFun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg);
+        _ ->
+            undefined
+    end.
+
+find_record_field(_Record, [], _Column, _Line) ->
+    undefined;
+find_record_field(Record, [{record_field, _, {atom, {L, Start}, Field}, _} | Tail], Column, Line) when L == Line, Start =< Column ->
+    End = Start + length(atom_to_list(Field)),
+    if
+        Column =< End -> {reference, {field, Record, Field}};
+        true -> find_record_field(Record, Tail, Column, Line)
+    end;
+find_record_field(Record, [_ | Tail], Column, Line) ->
+    find_record_field(Record, Tail, Column, Line).
+
+find_with_re(_File, undefined, _Column) ->
+    undefined;
+find_with_re(File, LineContents, Column) ->
+    case find_macro_reference(LineContents, Column) of
+        undefined -> find_include(File, LineContents, Column);
+        MacroReference -> MacroReference
+    end.
+
+find_macro_reference(LineContents, Column) ->
+    case re:run(LineContents, <<"\\?[A-Z_0-9a-z]+">>, [global]) of
+        {match, Matches} ->
+            case lists:filter(fun ([{Pos, Len}]) -> Column > Pos andalso Column =< Pos + Len end, Matches) of
+                [[{FoundPos, FoundLen}]] ->
+                    Macro = binary_to_atom(binary:part(LineContents, FoundPos + 1, FoundLen - 1), latin1),
+                    {reference, {macro, Macro}};
+                _ ->
+                    undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+find_include(File, LineContents, Column) ->
+    case re:run(LineContents, <<"-(include|include_lib)\\(\"([^\"]+)\"\\)\\.">>, [global]) of
+        {match, Matches} ->
+            IncludeFile = lists:foldl(fun
+                ([{Start, Len}, AttributePL, FilenamePL], undefined) when Column - 1 >= Start, Column < Start + Len ->
+                    case binary:part(LineContents, AttributePL) of
+                        <<"include">> -> resolve_include_file_path(File, binary:part(LineContents, FilenamePL));
+                        <<"include_lib">> -> find_libdir(binary:part(LineContents, FilenamePL))
+                    end;
+                (_, Acc) ->
+                    Acc
+            end, undefined, Matches),
+            case IncludeFile of
+                undefined -> undefined;
+                _ -> {include, IncludeFile}
+            end;
+        _ ->
+            undefined
+    end.
+
+resolve_include_file_path(File, IncludeFileName) ->
+    IncludePaths = lsp_parse:get_include_path(File),
+    Candidates = [filename:join(Path, IncludeFileName) || Path <- IncludePaths],
+    case lists:filter(fun filelib:is_file/1, Candidates) of
+        [First|_] -> First;
+        _ -> IncludeFileName
+    end.
+
+find_libdir(IncludeFileName) ->
+    case filename:split(IncludeFileName) of
+        [LibName | Remain] ->
+            case code:lib_dir(binary_to_atom(LibName)) of
+                {error, bad_name} ->
+                    gen_lsp_doc_server:find_source_file(IncludeFileName);
+                AbsLib ->
+                    filename:nativename(string:join([AbsLib | Remain], "/"))
+            end;
+        _ ->
+            undefined
+    end.
+
+local_function_references(File, Function, Arity) ->
+    FunctionLength = length(atom_to_list(Function)),
+    fold_in_syntax_tree(fun
+        ({call, {L, C}, {atom, _, FunctionName}, Args}, Acc) when Function =:= FunctionName, length(Args) == Arity ->
+            [{File, L, C, C + FunctionLength} | Acc];
+        (_SyntaxTree, Acc) ->
+            Acc
+    end, [], gen_lsp_doc_server:get_syntax_tree(File)).
+
+find_definition(_File, {_, {module, Module}}) ->
+    case gen_lsp_doc_server:get_module_file(Module) of
+        undefined -> undefined;
+        ModuleFile -> {ModuleFile, 1, 1, 1}
+    end;
+find_definition(_File, {include, IncludedFile}) ->
+    {IncludedFile, 1, 1, 1};
+find_definition(_File, {_, {function, Module, Function, Arity}}) ->
+    find_in_syntax_tree(fun
+        ({function, {L, Start}, FoundFunction, FoundArity, _}, CurrentFile) when Function =:= FoundFunction, Arity =:= FoundArity ->
+            {CurrentFile, L, Start, Start};
+        (_SyntaxTree, _CurrentFile) ->
+            undefined
+    end, gen_lsp_doc_server:get_module_file(Module));
+find_definition(File, {gen_msg_use, GenMsg}) ->
+    case match_gen_msg(gen_lsp_doc_server:get_syntax_tree(File), GenMsg) of
+        undefined -> undefined;
+        {ClauseLine, ClauseColumn} -> {File, ClauseLine, ClauseColumn, ClauseColumn}
+    end;
+find_definition(File, {_, {record, Record}}) ->
+    find_in_syntax_tree(fun
+        ({attribute, {L, Start}, record, {FoundRecord, _}}, CurrentFile) when Record =:= FoundRecord ->
+            {CurrentFile, L, Start, Start};
+        (_SyntaxTree, _CurrentFile) ->
+            undefined
+    end, File);
+find_definition(File, {_, {field, Record, Field}}) ->
+    find_in_syntax_tree(fun
+        ({attribute, _, record, {FoundRecord, Fields}}, CurrentFile) when Record =:= FoundRecord ->
+            find_field_definition(Field, Fields, CurrentFile);
+        (_SyntaxTree, _CurrentFile) ->
+            undefined
+    end, File);
+find_definition(File, {variable, {Variable, Line, Column}}) ->
+    case variable_references(File, Variable, Line, Column) of
+        [] -> undefined;
+        [{L, C} | _] -> {File, L, C, C}
+    end;
+find_definition(File, {_, {macro, Macro}}) ->
+    find_macro_definition(Macro, File);
+find_definition(_File, _What) ->
+    undefined.
+
+find_field_definition(_Field, [], _CurrentFile) ->
+    undefined;
+find_field_definition(Field, [{typed_record_field, {record_field, _, {atom, {Line, Column}, Field}}, _} | _], CurrentFile) ->
+    {CurrentFile, Line, Column, Column};
+find_field_definition(Field, [{typed_record_field, {record_field, _, {atom, {Line, Column}, Field}, _}, _} | _], CurrentFile) ->
+    {CurrentFile, Line, Column, Column};
+find_field_definition(Field, [{record_field, _, {atom, {Line, Column}, Field}} | _], CurrentFile) ->
+    {CurrentFile, Line, Column, Column};
+find_field_definition(Field, [{record_field, _, {atom, {Line, Column}, Field}, _} | _], CurrentFile) ->
+    {CurrentFile, Line, Column, Column};
+find_field_definition(Field, [_ | Tail], CurrentFile) ->
+    find_field_definition(Field, Tail, CurrentFile).
+
+variable_references(File, Variable, Line, Column) ->
+    FunctionWithVariable = find_function_with_line(gen_lsp_doc_server:get_syntax_tree(File), Line),
+    DoClause = fun ({clause, ClauseLC, _, _, _} = Clause, ClauseAcc) ->
+        VarLCs = erl_syntax_lib:fold(fun
+            ({var, LC, V}, Acc) when V =:= Variable -> [LC | Acc];
+            (_, Acc) -> Acc
+        end, [], Clause),
+        lists:foldl(fun (VarLC, Acc) ->
+            case Acc of
+                #{VarLC := _} -> Acc;
+                _ -> Acc#{VarLC => ClauseLC}
+            end
+        end, ClauseAcc, VarLCs)
+    end,
+    VarLC2ClauseLC = erl_syntax_lib:fold(fun
+        ({function, _FunctionLC, _Function, _Arity, Clauses}, Acc) ->
+            lists:foldl(DoClause, Acc, Clauses);
+        ({'fun', _FunLC, {clauses, Clauses}}, Acc) ->
+            lists:foldl(DoClause, Acc, Clauses);
+        (_S, ClauseAcc) ->
+            ClauseAcc
+    end, #{}, FunctionWithVariable),
+    case VarLC2ClauseLC of
+        #{{Line, Column} := ClauseLC} ->
+            lists:usort(lists:filtermap(fun
+                ({VarLC, ThisClauseLC}) when ThisClauseLC =:= ClauseLC -> {true, VarLC};
+                (_) -> false
+            end, maps:to_list(VarLC2ClauseLC)));
+        _ ->
+            []
+    end.
+
+find_macro_definition(Macro, File) -> find_macro_definition_in_files(Macro, [File]).
+
+find_macro_definition_in_files(_Macro, []) -> undefined;
+find_macro_definition_in_files(Macro, [File | Tail]) ->
+    Forms = gen_lsp_doc_server:get_dodged_syntax_tree(File),
+    case find_macro_definition(Macro, File, Forms) of
+        undefined ->
+            Included = lists:reverse(find_included_files(Forms, [])),
+            IncludePath = lsp_parse:get_include_path(File),
+            case find_macro_definition_in_files(Macro, [filename:join(Path, IncludedFile) || IncludedFile <- Included, Path <- IncludePath]) of
+                undefined -> find_macro_definition_in_files(Macro, Tail);
+                Result -> Result
+            end;
+        Result -> Result
+    end.
+
+find_macro_definition(_Macro, _File, undefined) ->
+    undefined;
+find_macro_definition(_Macro, _File, []) ->
+    undefined;
+find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{_, Line, Macro}, _]}} | _]) ->
+    {File, Line, 1, 1};
+find_macro_definition(Macro, File, [{tree, attribute, _, {attribute, {atom, _, define}, [{_, _, _, {_, {_, Line, Macro}, _}}, _]}} | _]) ->
+    {File, Line, 1, 1};
+find_macro_definition(Macro, File, [_ | Tail]) ->
+    find_macro_definition(Macro, File, Tail).
+
+find_included_files(undefined, Acc) -> Acc;
+find_included_files([], Acc) -> Acc;
+find_included_files([{tree, attribute, _, {attribute, {atom, _, include_lib}, [{string, _ , Name}]}} | Tail], Acc) ->
+    find_included_files(Tail, [Name | Acc]);
+find_included_files([{tree, attribute, _, {attribute, {atom, _, include}, [{string, _ , Name}]}} | Tail], Acc) ->
+    find_included_files(Tail, [Name | Acc]);
+find_included_files([_ | Tail], Acc) -> find_included_files(Tail, Acc).
 
 file_line(File, Line) ->
     Contents = case gen_lsp_doc_server:get_document_contents(File) of
@@ -42,20 +435,6 @@ file_line(File, Line) ->
         undefined
     end.
 
-hover_info(File, Line, Column) ->
-    Module = list_to_atom(filename:rootname(filename:basename(File))),
-    FileSyntax = gen_lsp_doc_server:get_syntax_tree(File),
-    What = element_at_position(Module, FileSyntax, Line, Column, file_line(File, Line)),
-    %gen_lsp_server:lsp_log("hover_info What:~p", [What]),
-    case What of
-        {function_use, FunctionModule, Function, Arity} ->
-            #{contents => function_description(FunctionModule, Function, Arity)};
-        {function_use, FunctionModule, Function, Arity, _Args} ->
-            #{contents => function_description(FunctionModule, Function, Arity)};
-        _ ->
-            #{contents => <<>>}
-    end.
-
 function_description(Module, Function) ->
     Help = gen_lsp_help_server:get_help(Module, Function),
     case Help of
@@ -69,33 +448,37 @@ function_description(Module, Function) ->
     end.
 
 function_description(Module, Function, Arity) ->
-    File = gen_lsp_doc_server:get_module_file(Module),
-    case gen_lsp_doc_server:get_syntax_tree(File) of
+    case gen_lsp_doc_server:get_module_file(Module) of
         undefined ->
             get_generic_help(Module, Function);
-        SyntaxTree ->
-            case lsp_utils:is_erlang_lib_file(File) of
-                false ->
-                case find_function(SyntaxTree, Function, Arity) of
-                    {function, _, _, _, Clauses} ->
-                        DocAsString = try edoc:layout(edoc:get_doc(File, [{hidden, true}, {private, true}]), 
-                            [{layout, hover_doc_layout}, {filter, [{function, {Function, Arity}}]} ]) of
-                                _Any -> _Any
-                            catch
-                                _Err:_Reason -> ""
-                            end,                                                                        
-                        FunctionHeaders = join_strings(lists:map(fun ({clause, _Location, Args, _Guard, _Body}) ->
-                            function_header(Function, Args)
-                        end, Clauses), "  \n") ++ "  \n" ++ DocAsString,
-                        list_to_binary(FunctionHeaders);
-                    _ ->
-                        %check if a BIF
-                        case lists:keyfind(Function,1, erlang:module_info(exports)) of
-                            {Function, _} -> gen_lsp_help_server:get_help(erlang, Function);
-                            _  -> <<>>
-                        end
-                end;
-                _ ->  get_generic_help(Module, Function)
+        File ->
+            case gen_lsp_doc_server:get_syntax_tree(File) of
+                undefined ->
+                    get_generic_help(Module, Function);
+                SyntaxTree ->
+                    case lsp_utils:is_erlang_lib_file(File) of
+                        false ->
+                        case find_function(SyntaxTree, Function, Arity) of
+                            {function, _, _, _, Clauses} ->
+                                DocAsString = try edoc:layout(edoc:get_doc(File, [{hidden, true}, {private, true}]), 
+                                    [{layout, hover_doc_layout}, {filter, [{function, {Function, Arity}}]} ]) of
+                                        _Any -> _Any
+                                    catch
+                                        _Err:_Reason -> ""
+                                    end,                                                                        
+                                FunctionHeaders = join_strings(lists:map(fun ({clause, _Location, Args, _Guard, _Body}) ->
+                                    function_header(Function, Args)
+                                end, Clauses), "  \n") ++ "  \n" ++ DocAsString,
+                                list_to_binary(FunctionHeaders);
+                            _ ->
+                                %check if a BIF
+                                case lists:keyfind(Function,1, erlang:module_info(exports)) of
+                                    {Function, _} -> gen_lsp_help_server:get_help(erlang, Function);
+                                    _  -> <<>>
+                                end
+                        end;
+                        _ ->  get_generic_help(Module, Function)
+                    end
             end
     end.
 
@@ -106,111 +489,11 @@ get_generic_help(Module, Function) ->
         _ -> Help
     end.
 
-references_info(File, Line, Column) ->
-    MapResult = fold_in_file_syntax_tree(
-        gen_lsp_doc_server:get_syntax_tree(File), 
-        #{location => {Line, Column}, references => []}, 
-        fun references_analyze/2),
-    References = maps:get(references, MapResult),
-    case maps:get(ref, MapResult, undefined) of
-        undefined -> #{result => <<"ko">>};
-        RefKey -> 
-            Result = lists:map(fun ({_, {L,C}}) -> 
-                #{uri => lsp_utils:file_to_file_uri(File), line => L, character => C}
-            end, lists:filter(fun ({K,_L}) -> K =:= RefKey end, References)),
-            #{result => <<"ok">>, references => Result}
-    end.
-
-references_analyze(SyntaxTree, Map) ->
-    {Line, Column} = maps:get(location, Map),
-    case SyntaxTree of
-    {function, {FLine, FColumn}, FuncName, Arity, _} when FLine =:= Line andalso FColumn =< Column -> 
-        FunKey = lists:flatten(io_lib:format("~p/~p", [FuncName,Arity])),
-        EndColumn = FColumn + length(atom_to_list(FuncName)),
-        NewMap = if 
-            Column =< EndColumn ->
-                maps:put(ref, FunKey, Map);
-            true -> Map
-        end,
-        NewMap;
-    {call, CLocation, {atom,_,FName},Args} -> 
-        FunKey1 = lists:flatten(io_lib:format("~p/~p", [FName,length(Args)])),
-        References = maps:get(references, Map) ++ [{FunKey1, CLocation}],
-        maps:put(references, References, Map);
-    _ -> Map
-    end.
-
-codelens_info(File) ->
-    %filter only defined functions
-    MapResult = maps:filter(fun (_K,V) -> maps:is_key(func_name, V) end,
-        fold_in_file_syntax_tree(gen_lsp_doc_server:get_syntax_tree(File), #{}, fun codelens_analyze/2)),
-    lists:filtermap(fun (V) ->
-        case maps:get(location, V, undefined) of
-            {Line, Column} ->
-                Count = maps:get(count, V),
-                FName = list_to_binary(atom_to_list(maps:get(func_name, V))),
-                {true, #{
-                    line => Line,
-                    character => Column,
-                    data => #{
-                        count => Count,
-                        func_name => FName,
-                        exported => maps:get(exported, V, false)
-                    }
-                }};
-            undefined -> false
-        end
-    end, maps:values(MapResult)).
-
-codelens_analyze(SyntaxTree, Map) ->
-    case SyntaxTree of
-    {function, Location, FuncName, Arity, _} -> 
-        FunKey = lists:flatten(io_lib:format("~p/~p", [FuncName,Arity])),
-        codelens_add_or_update_ref(Map, FunKey, FuncName, Location);
-    {call,_LocationCall, {atom,_,FName},Args} -> 
-        FunKey1 = lists:flatten(io_lib:format("~p/~p", [FName,length(Args)])),
-        codelens_add_or_update_refcount(Map, FunKey1, 1);
-    {attribute,_,export,Exports} ->
-        %export sample : [{start,0},{stop,0}]
-        lists:foldl(fun ({FuncName, Arity}, AccMap) ->
-            FunKey = lists:flatten(io_lib:format("~p/~p", [FuncName,Arity])),
-            codelens_add_or_update_exported(AccMap, FunKey, FuncName, true)
-        end, Map, Exports);
-    _ -> Map
-    end.
-
-codelens_add_or_update_exported(Map, Key, FuncName, Exported) ->
-    case maps:get(Key, Map, undefined) of
-    undefined -> maps:put(Key, #{exported => Exported, count=> 0, func_name => FuncName}, Map);
-    FMap -> 
-        NewFMap = maps:put(exported, Exported, FMap), 
-        NewFMap1 = maps:put(func_name, FuncName, NewFMap), 
-        maps:put(Key, NewFMap1, Map)
-    end.
-
-codelens_add_or_update_ref(Map, Key, FuncName, Location) ->
-    case maps:get(Key, Map, undefined) of
-    undefined -> maps:put(Key, #{location => Location, count=> 0, func_name => FuncName}, Map);
-    FMap -> 
-        NewFMap = maps:put(location, Location, FMap), 
-        NewFMap1 = maps:put(func_name, FuncName, NewFMap), 
-        maps:put(Key, NewFMap1, Map)
-    end.
-    
-codelens_add_or_update_refcount(Map, Key, Count) ->
-    case maps:get(Key, Map, undefined) of
-    undefined -> maps:put(Key, #{count=> Count}, Map);
-    FMap ->
-        NewCount = maps:get(count, FMap) + Count,
-        NewFMap = maps:put(count, NewCount, FMap), 
-        maps:put(Key, NewFMap, Map)
-    end.
-
 symbol_info(Uri, File) ->
     %return all symbols for the specified document 
     SyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
     %gen_lsp_server:lsp_log("syntax for symbolinfo : ~p", [SyntaxTree]),
-    fold_in_file_syntax_tree(SyntaxTree, [], fun (S, Acc) -> symbolinfo_analyze(Uri, S, Acc) end).
+    fold_in_syntax_tree(fun (S, Acc) -> symbolinfo_analyze(Uri, S, Acc) end, [], SyntaxTree).
 
 symbolinfo_analyze(Uri, SyntaxTree, List) ->
     case SyntaxTree of
@@ -276,375 +559,25 @@ join_strings([String], _) ->
 join_strings([String|Rest], Joiner) ->
     String ++ Joiner ++ join_strings(Rest, Joiner).
 
-fold_in_file_syntax_tree(FileSyntaxTree, StartAcc, Fun) ->
-    % FileStyntaxTree is [] of TopLevelStyntaxTree
-    % post-order traversal, then
-    lists:foldl(fun (TopLevelSyntaxTree, Acc) ->
-        erl_syntax_lib:fold(Fun, Acc, TopLevelSyntaxTree)
-        end, StartAcc, FileSyntaxTree).
-
 find_in_file_syntax_tree(FileSyntaxTree, Fun1) ->
     DefaultVal = case Fun1 of
         {function, Fun} -> {{undefined, undefined}, undefined};
         Fun -> {undefined, undefined}
     end,
-    fold_in_file_syntax_tree(FileSyntaxTree, DefaultVal, 
-        fun (SyntaxTree, {SingleAcc, CurrentFile}) ->
-            UpdatedFile = case SyntaxTree of
-                {attribute, _, file, {FileName, _}} -> FileName;
-                _ -> CurrentFile
-            end,
-            case SingleAcc of
-                undefined ->
-                    {Fun(SyntaxTree, UpdatedFile), UpdatedFile};
-                {undefined, DefaultTree} ->
-                    {Fun(SyntaxTree, DefaultTree, UpdatedFile), UpdatedFile};
-                _ ->
-                    {SingleAcc, CurrentFile}
-            end
-        end).
-
-element_at_position(CurrentModule, FileSyntaxTree, Line, Column, LineContents) ->
-    Fun = fun
-        ({tuple, {L, StartTuple}, Args}, _) when L =:= Line, Column > StartTuple ->
-            find_definition_in_args(Args, Column, Line, CurrentModule);
-        ({cons, {L, StartCons}, _, _} = Cons, _) when L =:= Line, Column > StartCons ->
-            case cons_to_list(Cons, []) of
-                false -> undefined;
-                Args -> find_definition_in_args(Args, Column, Line, CurrentModule)
-            end;
-        ({call, {L, StartColumn}, {atom, {L, StartColumn}, Function}, Args}, _) ->
-            EndColumn = StartColumn + length(atom_to_list(Function)),
-            if
-                L =:= Line, StartColumn =< Column, Column =< EndColumn -> {function_use, CurrentModule, Function, length(Args)};
-                true -> find_definition_in_args(Args, Column, Line, CurrentModule)
-            end;
-        ({attribute, {_L, _StartColumn}, export, _Exports}, _) ->
-            find_function_in_export(CurrentModule, LineContents, Column);
-        ({attribute, _, file, {HrlFile, _}}, _) ->
-            process_hrl_filename(HrlFile, LineContents, Column);
-        ({call, {_, _}, {remote, {_, _}, {atom, {_, MStartColumn}, Module}, {atom, {L, StartColumn}, Function} = Prefix}, Args}, _) ->
-            MEndColumn = MStartColumn + length(atom_to_list(Module)), 
-            EndColumn = StartColumn + length(atom_to_list(Function)),
-            if
-                L =:= Line, MStartColumn =< Column, Column =< MEndColumn -> {module_use, Module};
-                L =:= Line, StartColumn =< Column, Column =< EndColumn -> {function_use, Module, Function, length(Args), Args};
-                true ->
-                    GenFun = fun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg) ->
-                        GEndColumn = GenMsgColumn + length(atom_to_list(AtomMsg)),
-                        case Line =:= GenMsgLine andalso GenMsgColumn =< Column andalso Column =< GEndColumn of
-                            true when Module == gen_server -> {gen_msg_use, [GenMsg]};
-                            true when Module == gen_statem ->
-                                PreMsg = case Function of
-                                    call ->
-                                        {tuple, {0, 0}, [Prefix, {var, {0, 0}, 'From'}]};
-                                    _ -> Prefix
-                                end,
-                                {gen_msg_use, [PreMsg, GenMsg]};
-                            _ -> false
-                        end
-                    end,
-                    GenResult = case Args of
-                        [_, {atom, {GenMsgLine, GenMsgColumn}, AtomMsg} = GenMsg | _] ->
-                            GenFun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg);
-                        [_, {tuple, _, [{atom, {GenMsgLine, GenMsgColumn}, AtomMsg} | _]} = GenMsg | _] ->
-                            GenFun(GenMsgLine, GenMsgColumn, AtomMsg, GenMsg);
-                        _ -> false
-                    end,
-                    case GenResult of
-                        false -> find_definition_in_args(Args, Column, Line, CurrentModule);
-                        _ -> GenResult
-                    end
-            end;
-        ({'fun',{L, StartColumn}, {function, Function, Arity}}, _) when L =:= Line andalso StartColumn =< Column ->
-            EndColumn = StartColumn + 4 + length(atom_to_list(Function)),
-            if
-                Column =< EndColumn -> {function_use, CurrentModule, Function, Arity};
-                true -> undefined
-            end;
-        ({'fun', {_, _}, {function, {atom, {_, _}, Module}, {atom, {L, StartColumn}, Function}, {integer, {_, _}, Arity}}}, _) when L =:= Line andalso StartColumn =< Column ->
-            EndColumn = StartColumn + length(atom_to_list(Function)),
-            if
-                Column =< EndColumn -> {function_use, Module, Function, Arity};
-                true -> undefined
-            end;
-        ({var, {L, StartColumn}, Variable}, _) when L =:= Line andalso StartColumn =< Column ->
-            EndColumn = StartColumn + length(atom_to_list(Variable)),
-            if
-                Column =< EndColumn -> {variable, Variable, L, StartColumn};
-                true -> undefined
-            end;
-        ({record, {L, StartColumn}, Record, Fields}, _) ->
-            EndColumn = StartColumn + length(atom_to_list(Record)),
-            if
-                L =:= Line, StartColumn =< Column, Column =< EndColumn -> {record, Record};
-                true -> find_record_field_use(Record, Fields, Column, Line)
-            end;
-        ({record, {L, StartColumn}, _, Record, Fields}, _) ->
-            EndColumn = StartColumn + length(atom_to_list(Record)),
-            if
-                L =:= Line, StartColumn =< Column, Column =< EndColumn -> {record, Record};
-                true -> find_record_field_use(Record, Fields, Column, Line)
-            end;
-        ({record_field, {L, RecordSttartColumn}, _, Record, {atom, {L, FieldStartColumn}, Field}}, _) when L =:= Line andalso RecordSttartColumn =< Column ->
-            FieldEndColumn = FieldStartColumn + length(atom_to_list(Field)),
-            if
-                Column < FieldStartColumn -> {record, Record};
-                Column < FieldEndColumn -> {field, Record, Field};
-                true -> undefined
-            end;
-        ({record_index, {L, RecordSttartColumn}, Record, {atom, {L, FieldStartColumn}, Field}}, _) when L =:= Line andalso RecordSttartColumn =< Column ->
-            FieldEndColumn = FieldStartColumn + length(atom_to_list(Field)),
-            if
-                Column < FieldStartColumn -> {record, Record};
-                Column < FieldEndColumn -> {field, Record, Field};
-                true -> undefined
-            end;
-        (_SyntaxTree, _File) ->
-            undefined
-    end,
-    case find_macro_use(LineContents, Column) of
-        undefined ->
-            case find_in_file_syntax_tree(FileSyntaxTree, Fun) of
-                {{function_use, _, _, _} = Export, _File} -> Export;
-                {{function_use, _, _, _, _} = Export, _File} -> Export;
-                {What, _File} -> What
-            end;
-        MacroUse -> MacroUse
-            
-    end.
-
-cons_to_list({nil,_}, List) -> lists:reverse(List);
-cons_to_list({cons, _, Data, Cons}, List) ->
-    cons_to_list(Cons, [Data|List]);
-cons_to_list(_, _List) -> false.
-
-process_hrl_filename(File, LineContents, Column) ->
-    MatchResult = find_include_filename(LineContents, Column),
-    case MatchResult of
-        {include, IncludeFileName, true} ->
-            %gen_lsp_server:lsp_log("attr hrl match include", []),
-            {hrl, resolve_include_file_path(File, IncludeFileName)};
-        {include_lib, IncludeFileName, true} ->
-            %gen_lsp_server:lsp_log("attr hrl match include_lib", []),            
-            find_libdir(IncludeFileName);
-        _ -> undefined
-    end.
-
-resolve_include_file_path(File, IncludeFileName) ->
-    IncludePaths = lsp_parse:get_include_path(File),
-    Candidates = [filename:join(Path, IncludeFileName) || Path <- IncludePaths],
-    case lists:filter(fun filelib:is_file/1, Candidates) of
-        [First|_] -> First;
-        _ -> IncludeFileName
-    end.
-find_libdir(IncludeFileName) ->
-    case filename:split(IncludeFileName) of
-        [LibName|Remain] ->
-            case code:lib_dir(LibName) of
-                {error,bad_name} -> undefined;
-                AbsLib -> {hrl, filename:nativename(string:join([AbsLib|Remain], "/")) }
-            end;
-        _ -> undefined
-    end.
-
-find_include_filename(LineContents, Column) ->
-    % regular expression, intead of binaries matching. Because a comment can be exists at the end of include line
-    case re:run(LineContents, <<"^-include(?<alib>|_lib)\\(\"(?<grp>.+)\"\\)">>, [global,{capture, all_names}]) of
-        {match, Matches} ->
-            case lists:nth(1,Matches) of
-                [{_,0},{Pos,Len}] -> %include
-                    IncludeFile =binary_to_list(binary:part(LineContents, Pos, Len)), 
-                    %gen_lsp_server:lsp_log("include found: ~p", [IncludeFile]),
-                    {include, IncludeFile, is_between(Column, 1, 10+Pos+Len)};
-                [{_,_},{Pos,Len}] -> %include_lib
-                    IncludeFile = binary_to_list(binary:part(LineContents, Pos, Len)),
-                    %gen_lsp_server:lsp_log("include_lib found: ~p", [IncludeFile]),
-                    {include_lib, IncludeFile, is_between(Column, 1, 14+Pos+Len)};                  
-                _ -> 
-                    undefined
-            end;
-        _ -> undefined
-    end.
-
-is_between(C, Start, End) ->
-    case C of
-    X when X >= Start andalso X =< End -> true;
-    _ -> false
-    end.
-find_macro_use(undefined, _Column) ->
-    undefined;
-find_macro_use(LineContents, Column) ->
-    case re:run(LineContents, <<"\\?[A-Z_0-9a-z]+">>, [global]) of
-        {match, Matches} ->
-            case lists:filter(fun ([{Pos, Len}]) -> Column > Pos andalso Column =< Pos + Len end, Matches) of
-                [[{FoundPos, FoundLen}]] -> {macro_use, binary_to_atom(binary:part(LineContents, FoundPos + 1, FoundLen - 1), latin1)};
-                _ -> undefined
-            end;
-        _ ->
-            undefined
-    end.
-
-find_definition_in_args([{atom, {ModLine, StartMod}, Module}, {atom, {ColumnLine, StartColumn}, Function}, ArityTuple | _] = [_ | Tail], Column, Line, CurrentModule) ->
-    EndMod = StartMod + length(atom_to_list(Module)),
-    EndColumn = StartColumn + length(atom_to_list(Function)),
-    case Line of
-        ModLine when StartMod =< Column, Column =< EndMod, Module =/= CurrentModule ->
-            case parse_arity_tuple(ArityTuple, 0) of
-                false -> find_definition_in_args(Tail, Column, Line, CurrentModule);
-                _Arity -> {module_use, Module}
-            end;
-        ColumnLine when StartColumn =< Column, Column =< EndColumn ->
-            case parse_arity_tuple(ArityTuple, 0) of
-                false -> find_definition_in_args(Tail, Column, Line, CurrentModule);
-                Arity -> {function_use, Module, Function, Arity}
-            end;
-        _ -> find_definition_in_args(Tail, Column, Line, CurrentModule)
-    end;
-find_definition_in_args([_ | Tail], Column, Line, CurrentModule) when length(Tail) > 2 ->
-    find_definition_in_args(Tail, Column, Line, CurrentModule);
-find_definition_in_args([{atom, {ModLine, StartMod}, Module}, {atom, {ColumnLine, StartColumn}, Function}], Column, Line, CurrentModule)  ->
-    EndMod = StartMod + length(atom_to_list(Module)),
-    EndColumn = StartColumn + length(atom_to_list(Function)),
-    case Line of
-        ModLine when StartMod =< Column, Column =< EndMod, Module =/= CurrentModule ->
-            {module_use, Module};
-        ColumnLine when StartColumn =< Column, Column =< EndColumn ->
-            {function_use, Module, Function, 1};
-        _ -> undefined
-    end;
-find_definition_in_args(_, _Column, _Line, _CurrentModule) -> undefined.
-
-parse_arity_tuple({cons, _, _, ArityTuple}, Num) ->
-    parse_arity_tuple(ArityTuple, Num + 1);
-parse_arity_tuple({nil, _}, Num) -> Num;
-parse_arity_tuple({var, _, _}, _Num) -> 1;
-parse_arity_tuple({tuple, _, _}, _Num) -> 1;
-parse_arity_tuple(_, _) -> false.
-
-find_function_in_export(_CurrentModule, undefined, _Column) ->
-    undefined;
-find_function_in_export(CurrentModule, LineContents, Column) ->
-    case re:run(LineContents, <<"([a-z][A-Z_0-9a-z@]*)/([0-9]+)">>, [global]) of
-        {match, Matches} ->
-            case lists:filter(fun ([{Pos, Len}, _, _]) -> Column > Pos andalso Column =< Pos + Len end, Matches) of
-                [[_, {NamePos, NameLen}, {ArityPos, ArityLen}]] ->
-                    Function = binary_to_atom(binary:part(LineContents, NamePos, NameLen), latin1),
-                    Arity = binary_to_integer(binary:part(LineContents, ArityPos, ArityLen)),
-                    {function_use, CurrentModule, Function, Arity};
-                _ -> undefined
-            end;
-        _ ->
-            undefined
-    end.
-
-find_record_field_use(_Record, [], _Column, _Line) ->
-    undefined;
-find_record_field_use(Record, [{record_field, _, {atom, {L, StartColumn}, Field}, _} | Tail], Column, Line) ->
-    EndColumn = StartColumn + length(atom_to_list(Field)),
-    if
-        L =:= Line, StartColumn =< Column, Column =< EndColumn -> {field, Record, Field};
-        true -> find_record_field_use(Record, Tail, Column, Line)
-    end;
-%% Non-atom record field, e.g. #rec{a = 1, _ = '_'} pattern or match spec
-find_record_field_use(Record, [_Head | Tail], Column, Line) ->
-    find_record_field_use(Record, Tail, Column, Line).
-
-find_element({module_use, Module}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    File = gen_lsp_doc_server:get_module_file(Module),
-    case gen_lsp_doc_server:get_syntax_tree(File) of
-        undefined -> undefined;
-        SyntaxTree ->
-            case find_module(SyntaxTree, Module) of
-                {attribute, {Line, Column}, _} -> {File, Line, Column};
-                _ -> undefined
-            end
-    end;
-find_element({hrl, HrlFile}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    {HrlFile, 1, 1};
-find_element({function_use, Module, Function, Arity}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    File = gen_lsp_doc_server:get_module_file(Module),
-    case gen_lsp_doc_server:get_syntax_tree(File) of
-        undefined -> undefined;
-        SyntaxTree ->
-            case find_function(SyntaxTree, Function, Arity) of
-                {function, {Line, Column}, _Function, _Arity, _Clauses} -> {File, Line, Column};
-                _ -> undefined
-            end
-    end;
-find_element({function_use, Module, Function, Arity, Args}, _CurrentFileSyntaxTree, _CurrentFile) ->
-    File = gen_lsp_doc_server:get_module_file(Module),
-    case gen_lsp_doc_server:get_syntax_tree(File) of
-        undefined -> undefined;
-        SyntaxTree ->
-            case find_function(SyntaxTree, Function, Arity) of
-                {function, {Line, Column}, _Function, _Arity, Clauses} ->
-                    case find_clause_location(Clauses, Args) of
-                        undefined -> {File, Line, Column};
-                        {ClauseLine, ClauseColumn} -> {File, ClauseLine, ClauseColumn}
-                    end;
-                _ -> undefined
-            end
-    end;
-find_element({gen_msg_use, GenMsg}, SyntaxTree, File) ->
-    case match_gen_msg(SyntaxTree, GenMsg) of
-        undefined -> undefined;
-        {ClauseLine, ClauseColumn} -> {File, ClauseLine, ClauseColumn}
-    end;
-find_element({record, Record}, CurrentFileSyntaxTree, _CurrentFile) ->
-    case find_record(CurrentFileSyntaxTree, Record) of
-        {{attribute, {Line, Column}, record, {Record, _}}, File} ->
-            {lsp_utils:to_string(File), Line, Column};
-        undefined ->
-            undefined
-    end;
-find_element({field, Record, Field}, CurrentFileSyntaxTree, _CurrentFile) ->
-    case find_record(CurrentFileSyntaxTree, Record) of
-        {{attribute, _, record, {Record, Fields}}, File} ->
-            find_record_field(Field, Fields, lsp_utils:to_string(File));
-        undefined ->
-            undefined
-    end;
-find_element({variable, Variable, Line, Column}, CurrentFileSyntaxTree, CurrentFile) ->
-    FunctionWithVariable = find_function_with_line(CurrentFileSyntaxTree, Line),
-    FunClausesShadowingVariable = lists:sort(erl_syntax_lib:fold(fun (SyntaxTree, SingleAcc) ->
-        case SyntaxTree of
-            {'fun', {_, _}, {clauses, Clauses}} ->
-                lists:foldl(fun (Clause, FunClauseAcc) ->
-                    FunHasVariable =
-                        variable_location_in_fun_clause(Variable, Line, Column, Clause) andalso
-                        variable_in_fun_clause_arguments(Variable, Clause),
-                    case FunHasVariable of
-                        true -> [Clause | FunClauseAcc];
-                        _ -> FunClauseAcc
-                    end
-                end, SingleAcc, Clauses);
-            {function, _, _, _, ClausesList} ->
-                matched_fun_clause(lists:reverse(ClausesList), Line);
+    fold_in_syntax_tree(fun (SyntaxTree, {SingleAcc, CurrentFile}) ->
+        UpdatedFile = case SyntaxTree of
+            {attribute, _, file, {FileName, _}} -> FileName;
+            _ -> CurrentFile
+        end,
+        case SingleAcc of
+            undefined ->
+                {Fun(SyntaxTree, UpdatedFile), UpdatedFile};
+            {undefined, DefaultTree} ->
+                {Fun(SyntaxTree, DefaultTree, UpdatedFile), UpdatedFile};
             _ ->
-                SingleAcc
+                {SingleAcc, CurrentFile}
         end
-    end, [], FunctionWithVariable)),
-    case FunClausesShadowingVariable of
-        [] ->
-            case find_variable_occurrences(Variable, FunctionWithVariable) of
-                [{L, C} | _Tail] ->
-                    {CurrentFile, L, C};
-                _ ->
-                    undefined
-            end;
-        _ ->
-            [{L, C} | _] = find_variable_occurrences(Variable, lists:last(FunClausesShadowingVariable)),
-            {CurrentFile, L, C}
-    end;
-find_element({macro_use, Macro}, _CurrentFileSyntaxTree, CurrentFile) ->
-    lsp_syntax:find_macro_definition(Macro, CurrentFile);
-find_element(_, _CurrentFileSyntaxTree, _CurrentFile) ->
-    undefined.
-
-matched_fun_clause([{clause, {ClauseLine, _}, _, _, _} = Clause | _], Line) when ClauseLine =< Line -> [Clause];
-matched_fun_clause([_ | Tail], Line) -> matched_fun_clause(Tail, Line);
-matched_fun_clause([], _line) -> [].
+    end, DefaultVal, FileSyntaxTree).
 
 find_clause_location([{clause, Location, ClauseArgs, _, _} | TailClauses], Args) ->
     case comparison_args(Args, ClauseArgs) of
@@ -690,36 +623,18 @@ find_function_with_line(FileSyntaxTree, Line) ->
         _ -> undefined
     end.
 
-find_variable_occurrences(Variable, Tree) ->
-    lists:sort(find_variable_occurrences(Variable, Tree, [])).
-
-find_variable_occurrences(Variable, {var, {Line, Column}, Variable}, Acc) ->
-    [{Line, Column} | Acc];
-find_variable_occurrences(Variable, T, Acc) when is_tuple(T) ->
-    find_variable_occurrences(Variable, tuple_to_list(T), Acc);
-find_variable_occurrences(Variable, [H | T], Acc) ->
-     find_variable_occurrences(Variable, T, find_variable_occurrences(Variable, H, Acc));
-find_variable_occurrences(_Variable, _, Acc) ->
-    Acc.
-
-variable_location_in_fun_clause(Variable, Line, Column, Clause) ->
-    lists:member({Line, Column}, find_variable_occurrences(Variable, Clause)).
-
-variable_in_fun_clause_arguments(Variable, {clause, {_, _}, Arguments, _, _}) ->
-    length(find_variable_occurrences(Variable, Arguments)) > 0.
-
 get_function_arities(Module, Function) ->
     File = gen_lsp_doc_server:get_module_file(Module),
     case gen_lsp_doc_server:get_syntax_tree(File) of
         undefined ->
             [];
         FileSyntaxTree ->
-            lists:sort(fold_in_file_syntax_tree(FileSyntaxTree, [], fun
+            lists:sort(fold_in_syntax_tree(fun
                 ({function, _Position, FoundFunction, Arity, _Clauses}, Acc) when FoundFunction =:= Function ->
                     [Arity | Acc];
                 (_, Acc) ->
                     Acc
-            end))
+            end, [], FileSyntaxTree))
     end.
 
 match_gen_msg(FileSyntaxTree, GenMsg) ->
@@ -752,12 +667,6 @@ find_function(FileSyntaxTree, Function, Arity) ->
     end,
     SyntaxTree.
 
-find_module(FileSyntaxTree, Module) ->
-    case lists:keyfind(module, 3, FileSyntaxTree) of
-    {attribute, Position, module, Module} -> {attribute, Position, Module};
-    _ -> undefined
-    end.
-
 find_record(FileSyntaxTree, Record) ->
     Fun = fun (SyntaxTree, _File) ->
         case SyntaxTree of
@@ -767,15 +676,14 @@ find_record(FileSyntaxTree, Record) ->
     end,
     find_in_file_syntax_tree(FileSyntaxTree, Fun).
 
-find_record_field(_Field, [], _CurrentFile) ->
-    undefined;
-find_record_field(Field, [{typed_record_field, {record_field, _, {atom, {Line, Column}, Field}}, _} | _], CurrentFile) ->
-    {CurrentFile, Line, Column};
-find_record_field(Field, [{typed_record_field, {record_field, _, {atom, {Line, Column}, Field}, _}, _} | _], CurrentFile) ->
-    {CurrentFile, Line, Column};
-find_record_field(Field, [{record_field, _, {atom, {Line, Column}, Field}} | _], CurrentFile) ->
-    {CurrentFile, Line, Column};
-find_record_field(Field, [{record_field, _, {atom, {Line, Column}, Field}, _} | _], CurrentFile) ->
-    {CurrentFile, Line, Column};
-find_record_field(Field, [_ | Tail], CurrentFile) ->
-    find_record_field(Field, Tail, CurrentFile).
+fold_references(Fun, Init, FileSyntaxTree) ->
+    fold_in_syntax_tree(fun
+        ({call, {_, _}, {remote, {_, _}, {atom, {ModuleLine, ModuleColumn}, Module}, {atom, {_FunctionLine, FunctionColumn}, Function}}, Args}, Acc) ->
+            End = FunctionColumn + length(atom_to_list(Function)),
+            Fun({function, Module, Function, length(Args)}, ModuleLine, ModuleColumn, End, Acc);
+        ({'fun', {_, _}, {function, {atom, {ModuleLine, ModuleColumn}, Module}, {atom, {_, _}, Function}, {integer, {_, Start}, Arity}}}, Acc) ->
+            End = Start + length(integer_to_list(Arity)),
+            Fun({function, Module, Function, Arity}, ModuleLine, ModuleColumn, End, Acc);
+        (_Syntax, Acc) ->
+            Acc
+    end, Init, FileSyntaxTree).

--- a/apps/erlangbridge/src/lsp_parse.erl
+++ b/apps/erlangbridge/src/lsp_parse.erl
@@ -1,0 +1,225 @@
+-module(lsp_parse).
+-export([parse_source_file/2, file_syntax_tree/1, module_syntax_tree/1, get_include_path/1, parse_config_file/2]).
+
+parse_source_file(File, ContentsFile) ->
+    case epp_parse_file(ContentsFile, get_include_path(File), get_define_from_rebar_config(File)) of
+        {ok, FileSyntaxTree} ->
+            UpdatedSyntaxTree = update_file_in_forms(File, ContentsFile, FileSyntaxTree),
+            gen_lsp_doc_server:set_document_syntax_tree(File, UpdatedSyntaxTree),
+            case epp_dodger:parse_file(ContentsFile) of
+                {ok, Forms} -> gen_lsp_doc_server:set_document_dodged_syntax_tree(File, Forms);
+                _ -> ok
+            end,
+            #{parse_result => true};
+        _ ->
+            #{parse_result => false, error_message => <<"Cannot open file">>}
+    end.
+
+file_syntax_tree(File) ->
+    case gen_lsp_doc_server:get_document_syntax_tree(File) of
+      undefined ->
+	  case epp_parse_file(File, get_include_path(File), get_define_from_rebar_config(File)) of
+	    {ok, FileSyntaxTree} -> FileSyntaxTree;
+	    _Err -> throw("Cannot parse file " ++ File)
+	  end;
+      FileSyntaxTree ->
+          FileSyntaxTree
+    end.
+
+module_syntax_tree(Module) ->
+    File = gen_lsp_doc_server:get_module_file(Module),
+    case File of
+      undefined -> undefined;
+      _ -> {file_syntax_tree(File), File}
+    end.
+
+parse_config_file(File, ContentsFile) ->
+    case file:path_consult(filename:dirname(ContentsFile), ContentsFile) of
+      {ok,_, _} -> #{parse_result => true};
+      {error, Reason} -> #{
+            parse_result => true,
+            errors_warnings => [#{type => <<"error">>,
+            file => list_to_binary(File),
+		    info => extract_info(Reason)}] }
+    end.
+
+get_include_path(File) ->
+    Candidates = get_standard_include_paths() ++
+		        get_settings_include_paths() ++
+		        get_file_include_paths(File) ++
+		        get_include_paths_from_rebar_config(File),
+    Paths = lists:filter(fun filelib:is_dir/1, Candidates),
+    gen_lsp_server:lsp_log("get_include_path: ~p", [Paths]),
+    Paths.
+
+get_standard_include_paths() ->
+    RootDir = gen_lsp_config_server:root(),
+    [
+        filename:join([RootDir, "_build", "default", "lib"]),
+        filename:join([RootDir, "_build", "default", "plugins"]),
+        filename:join([RootDir, "apps"]),
+        filename:join([RootDir, "lib"])
+    ].
+
+get_settings_include_paths() ->
+    SettingPaths = gen_lsp_config_server:includePaths(),
+    RootDir = gen_lsp_config_server:root(),
+    lists:map(fun (Path) -> 
+        lsp_utils:absolute_path(RootDir, Path) 
+    end, SettingPaths).
+
+get_file_include_paths(File) ->
+    Paths = [filename:dirname(File), filename:rootname(File)],
+    case get_file_include_directory(File) of
+        undefined -> 
+            Paths;
+        Path -> 
+            [Path|Paths]
+    end.
+
+get_file_include_directory(File) ->
+    case lists:reverse(filename:split(filename:dirname(File))) of
+        [DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
+	        filename:join(lists:reverse(["include"|Rest]));
+        [_, DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
+	        filename:join(lists:reverse(["include"|Rest]));
+        _Other -> 
+            undefined
+    end.
+
+get_include_paths_from_rebar_config(File) ->
+    RebarConfig = find_rebar_config(filename:dirname(File)),
+    case RebarConfig of
+      undefined ->
+          [];
+      _ ->
+	  Consult = file:consult(RebarConfig),
+	  ErlOptsPaths = case Consult of
+			   {ok, Terms} ->
+			       ErlOpts = proplists:get_value(erl_opts, Terms, []),
+			       IncludePaths = proplists:get_all_values(i, ErlOpts),
+			       lists:map(fun (Path) ->
+						 filename:absname(Path, filename:dirname(RebarConfig))
+					 end, IncludePaths);
+			   _ -> 
+                   []
+			 end,
+        Deps = [],
+        %TODO: if include of each rebar dependency should be add to include paths, uncomment below 
+    %   Deps = case Consult of
+    %       {ok, DepsTerms} ->
+    %         Profiles = proplists:get_value(profiles, DepsTerms, []),
+    %         ErlDeps = lists:flatmap(fun({_,Opts})-> proplists:get_value(deps,Opts) end, Profiles),
+    %         RootDir = gen_lsp_config_server:root(),
+    %         [filename:join([RootDir, "_build", "default", "plugins", X, "include"]) || X <- ErlDeps ];
+    %       _ -> 
+    %         []
+    %       end,
+	  DefaultPaths = [filename:dirname(RebarConfig), filename:join([filename:dirname(RebarConfig), "include"])],
+	  ErlOptsPaths ++ Deps ++ DefaultPaths
+    end.
+
+extract_info({Line, Module, MessageBody}) when is_number(Line) ->
+    extract_info({{Line, 1}, Module, MessageBody});
+extract_info({{Line, Column}, Module, MessageBody}) ->
+    % samples of X
+    %{20,erl_parse,["syntax error before: ","load_xy"]}
+    %{11,erl_lint,{undefined_function,{load_xy,1}}}]}
+    #{
+        line => Line, 
+        character => Column,
+        message => erlang:list_to_binary(lists:flatten(apply(Module, format_error, [MessageBody]), []))
+    }.
+
+get_define_from_rebar_config(File) ->
+    RebarConfig = find_rebar_config(filename:dirname(File)),
+    case RebarConfig of
+        undefined -> 
+            [];
+        _ ->
+	        Consult = file:consult(RebarConfig),
+	        ErlOptsDefines = case Consult of
+			    {ok, Terms} ->
+				ErlOpts = proplists:get_value(erl_opts, Terms, []),
+				 Defines = rebar_define_to_epp_define(proplists:lookup_all(d, ErlOpts)),
+				 gen_lsp_server:lsp_log("get_defines: ~p", [Defines]),
+				 Defines;
+			     _ -> 
+                     []
+			   end,
+	  DefaultDefines = [],
+	  ErlOptsDefines ++ DefaultDefines
+    end.
+
+find_rebar_config(Dir) ->
+    RebarConfig = filename:join(Dir, "rebar.config"),
+    case filelib:is_file(RebarConfig) of
+      true ->
+          RebarConfig;
+      _ ->
+	  Elements = filename:split(Dir),
+	  case Elements of
+	    [_] ->
+            undefined;
+	    _ ->
+		find_rebar_config(filename:join(lists:droplast(Elements)))
+	  end
+    end.
+
+epp_parse_file(File, IncludePath, Defines) ->
+    case otp_24_or_newer() of
+        true ->
+            case epp:parse_file(as_string(File), [{includes, IncludePath}, {macros, Defines}, {location, {1, 1}}]) of
+                {ok, Result} ->
+                    {ok, Result};
+                _Err -> 
+                    gen_lsp_server:lsp_log("epp_parse_file error : ~p", [_Err]),
+                    {error, file_could_not_parsed}
+            end;
+        false ->
+            case file:open(File, [read]) of
+                {ok, FIO} ->
+                    Ret = do_epp_parse_file(File, FIO, IncludePath, Defines),
+                    file:close(FIO),
+                    Ret;
+                _Err -> 
+                    gen_lsp_server:lsp_log("epp_parse_file error : ~p", [_Err]),
+                    {error, file_could_not_opened}
+            end
+    end.
+
+do_epp_parse_file(File, FIO, IncludePath, Defines) ->
+    case epp:open(as_string(File), FIO, {1,1}, IncludePath, Defines) of
+        {ok, Epp} -> {ok, epp:parse_file(Epp)};
+        {error, _Err} -> {error, _Err}
+    end.
+
+as_string(Text) when is_binary(Text) ->
+    binary_to_list(Text);
+as_string(Text) -> 
+    Text.
+
+rebar_define_to_epp_define([]) -> 
+    [];
+rebar_define_to_epp_define([none]) -> 
+    [];
+rebar_define_to_epp_define([H|T]) ->
+    case H of
+      {d, Atom, Value} -> [{Atom, Value}] ++ rebar_define_to_epp_define(T);
+      {d, Atom} -> [Atom] ++ rebar_define_to_epp_define(T);
+      _ -> rebar_define_to_epp_define(T)
+    end.
+
+update_file_in_forms(File, File, FileSyntaxTree) ->
+    FileSyntaxTree;
+update_file_in_forms(File, ContentsFile, FileSyntaxTree) ->
+    lists:map(fun 
+        ({attribute, A1, file, {FunContentsFile, A2}}) when FunContentsFile =:= ContentsFile ->
+		      {attribute, A1, file, {File, A2}};
+		  (Form) ->
+              Form
+	      end, FileSyntaxTree).
+
+otp_24_or_newer() ->
+    VersionNumber = (catch list_to_integer(erlang:system_info(otp_release))),
+    is_integer(VersionNumber) andalso VersionNumber >= 24.

--- a/apps/erlangbridge/src/lsp_parse.erl
+++ b/apps/erlangbridge/src/lsp_parse.erl
@@ -28,10 +28,10 @@ parse_config_file(File, ContentsFile) ->
     end.
 
 get_include_path(File) ->
-    Candidates = get_standard_include_paths() ++
-		        get_settings_include_paths() ++
-		        get_file_include_paths(File) ++
-		        get_include_paths_from_rebar_config(File),
+    Candidates = get_file_include_paths(File) ++
+        get_settings_include_paths() ++
+        get_include_paths_from_rebar_config(File) ++
+        get_standard_include_paths(),
     Paths = lists:filter(fun filelib:is_dir/1, Candidates),
     gen_lsp_server:lsp_log("get_include_path: ~p", [Paths]),
     Paths.
@@ -39,10 +39,10 @@ get_include_path(File) ->
 get_standard_include_paths() ->
     RootDir = gen_lsp_config_server:root(),
     [
-        filename:join([RootDir, "_build", "default", "lib"]),
-        filename:join([RootDir, "_build", "default", "plugins"]),
         filename:join([RootDir, "apps"]),
-        filename:join([RootDir, "lib"])
+        filename:join([RootDir, "lib"]),
+        filename:join([RootDir, "_build", "default", "lib"]),
+        filename:join([RootDir, "_build", "default", "plugins"])
     ].
 
 get_settings_include_paths() ->

--- a/apps/erlangbridge/src/lsp_parse.erl
+++ b/apps/erlangbridge/src/lsp_parse.erl
@@ -6,10 +6,14 @@ parse_source_file(File, ContentsFile) ->
         {ok, FileSyntaxTree} ->
             UpdatedSyntaxTree = update_file_in_forms(File, ContentsFile, FileSyntaxTree),
             case epp_dodger:parse_file(ContentsFile) of
-                {ok, Forms} -> {UpdatedSyntaxTree, Forms};
-                _ -> {UpdatedSyntaxTree, undefined}
+                {ok, Forms} ->
+                    {UpdatedSyntaxTree, Forms};
+                _ ->
+                    io:format("epp_dodger:parse_file could not parse ~p~n", [File]),
+                    {UpdatedSyntaxTree, undefined}
             end;
         _ ->
+            io:format("epp:parse_file could not parse ~p~n", [File]),
             {undefined, undefined}
     end.
 

--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -3,7 +3,7 @@
 -export([validate_parsed_source_file/1, find_macro_definition/2]).
 
 validate_parsed_source_file(File) ->
-    FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
+    FileSyntaxTree = gen_lsp_doc_server:get_syntax_tree(File),
     BehaviourModulea = behaviour_modules(FileSyntaxTree),
     ParseTranformModules = parse_transforms(FileSyntaxTree),
     ModulesToDelete = load_not_loaded_modules(BehaviourModulea ++ ParseTranformModules),
@@ -16,14 +16,7 @@ find_macro_definition(Macro, File) -> find_macro_definition_in_files(Macro, [Fil
 
 find_macro_definition_in_files(_Macro, []) -> undefined;
 find_macro_definition_in_files(Macro, [File | Tail]) ->
-    Forms = case gen_lsp_doc_server:get_document_dodged_syntax_tree(File) of
-        undefined ->
-            case epp_dodger:parse_file(File) of
-                {ok, F} -> F;
-                _ -> undefined
-            end;
-        F -> F
-    end,
+    Forms = gen_lsp_doc_server:get_dodged_syntax_tree(File),
     case find_macro_definition(Macro, File, Forms) of
         undefined ->
             Included = lists:reverse(find_included_files(Forms, [])),

--- a/apps/erlangbridge/src/lsp_syntax.erl
+++ b/apps/erlangbridge/src/lsp_syntax.erl
@@ -1,21 +1,6 @@
 -module(lsp_syntax).
 
--export([file_syntax_tree/1, module_syntax_tree/1, parse_config_file/2, parse_source_file/2, 
-    validate_parsed_source_file/1, find_macro_definition/2, get_include_path/1]).
-
-parse_source_file(File, ContentsFile) ->
-    case epp_parse_file(ContentsFile, get_include_path(File), get_define_from_rebar_config(File)) of
-        {ok, FileSyntaxTree} ->
-            UpdatedSyntaxTree = update_file_in_forms(File, ContentsFile, FileSyntaxTree),
-            gen_lsp_doc_server:set_document_syntax_tree(File, UpdatedSyntaxTree),
-            case epp_dodger:parse_file(ContentsFile) of
-                {ok, Forms} -> gen_lsp_doc_server:set_document_dodged_syntax_tree(File, Forms);
-                _ -> ok
-            end,
-            #{parse_result => true};
-        _ ->
-            #{parse_result => false, error_message => <<"Cannot open file">>}
-    end.
+-export([validate_parsed_source_file/1, find_macro_definition/2]).
 
 validate_parsed_source_file(File) ->
     FileSyntaxTree = gen_lsp_doc_server:get_document_syntax_tree(File),
@@ -26,34 +11,6 @@ validate_parsed_source_file(File) ->
     Result = lint(NewFileSyntaxTree, File),
     code_delete(ModulesToDelete),
     Result.
-
-parse_config_file(File, ContentsFile) ->
-    case file:path_consult(filename:dirname(ContentsFile), ContentsFile) of
-      {ok,_, _} -> #{parse_result => true};
-      {error, Reason} -> #{
-            parse_result => true,
-            errors_warnings => [#{type => <<"error">>,
-            file => list_to_binary(File),
-		    info => extract_info(Reason)}] }
-    end.
-
-file_syntax_tree(File) ->
-    case gen_lsp_doc_server:get_document_syntax_tree(File) of
-      undefined ->
-	  case epp_parse_file(File, get_include_path(File), get_define_from_rebar_config(File)) of
-	    {ok, FileSyntaxTree} -> FileSyntaxTree;
-	    _Err -> throw("Cannot parse file " ++ File)
-	  end;
-      FileSyntaxTree ->
-          FileSyntaxTree
-    end.
-
-module_syntax_tree(Module) ->
-    File = gen_lsp_doc_server:get_module_file(Module),
-    case File of
-      undefined -> undefined;
-      _ -> {file_syntax_tree(File), File}
-    end.
 
 find_macro_definition(Macro, File) -> find_macro_definition_in_files(Macro, [File]).
 
@@ -70,7 +27,7 @@ find_macro_definition_in_files(Macro, [File | Tail]) ->
     case find_macro_definition(Macro, File, Forms) of
         undefined ->
             Included = lists:reverse(find_included_files(Forms, [])),
-            IncludePath = get_include_path(File),
+            IncludePath = lsp_parse:get_include_path(File),
             case find_macro_definition_in_files(Macro, [filename:join(Path, IncludedFile) || IncludedFile <- Included, Path <- IncludePath]) of
                 undefined -> find_macro_definition_in_files(Macro, Tail);
                 Result -> Result
@@ -97,16 +54,6 @@ find_included_files([{tree, attribute, _, {attribute, {atom, _, include}, [{stri
     find_included_files(Tail, [Name | Acc]);
 find_included_files([_ | Tail], Acc) -> find_included_files(Tail, Acc).
 
-update_file_in_forms(File, File, FileSyntaxTree) ->
-    FileSyntaxTree;
-update_file_in_forms(File, ContentsFile, FileSyntaxTree) ->
-    lists:map(fun 
-        ({attribute, A1, file, {FunContentsFile, A2}}) when FunContentsFile =:= ContentsFile ->
-		      {attribute, A1, file, {File, A2}};
-		  (Form) ->
-              Form
-	      end, FileSyntaxTree).
-
 behaviour_modules(undefined) ->
     [];
 behaviour_modules(FileSyntaxTree) ->
@@ -132,7 +79,7 @@ load_not_loaded_modules(Modules) ->
                         gen_lsp_server:lsp_log("cannot find module '~p'", [Module]),
                         Acc;
                     SourceFile ->
-                        Options = [binary, report_errors, report_warningsk | [{i, Path} || Path <- get_include_path(SourceFile)]],
+                        Options = [binary, report_errors, report_warningsk | [{i, Path} || Path <- lsp_parse:get_include_path(SourceFile)]],
                         case compile:file(SourceFile, Options) of
                             {ok, ModuleName, Binary} -> 
                                 case code:load_binary(ModuleName, lists:flatten(io_lib:format("~p.beam", [ModuleName])), Binary) of
@@ -172,174 +119,6 @@ code_delete([Module | Modules]) ->
     code_delete(Modules);
 code_delete([]) -> ok.
 
-epp_parse_file(File, IncludePath, Defines) ->
-    case otp_24_or_newer() of
-        true ->
-            case epp:parse_file(as_string(File), [{includes, IncludePath}, {macros, Defines}, {location, {1, 1}}]) of
-                {ok, Result} ->
-                    {ok, Result};
-                _Err -> 
-                    gen_lsp_server:lsp_log("epp_parse_file error : ~p", [_Err]),
-                    {error, file_could_not_parsed}
-            end;
-        false ->
-            case file:open(File, [read]) of
-                {ok, FIO} ->
-                    Ret = do_epp_parse_file(File, FIO, IncludePath, Defines),
-                    file:close(FIO),
-                    Ret;
-                _Err -> 
-                    gen_lsp_server:lsp_log("epp_parse_file error : ~p", [_Err]),
-                    {error, file_could_not_opened}
-            end
-    end.
-
-otp_24_or_newer() ->
-    VersionNumber = (catch list_to_integer(erlang:system_info(otp_release))),
-    is_integer(VersionNumber) andalso VersionNumber >= 24.
-
-do_epp_parse_file(File, FIO, IncludePath, Defines) ->
-    case epp:open(as_string(File), FIO, {1,1}, IncludePath, Defines) of
-        {ok, Epp} -> {ok, epp:parse_file(Epp)};
-        {error, _Err} -> {error, _Err}
-    end.
-
-as_string(Text) when is_binary(Text) ->
-    binary_to_list(Text);
-as_string(Text) -> 
-    Text.
-
-get_include_path(File) ->
-    Candidates = get_standard_include_paths() ++
-		        get_settings_include_paths() ++
-		        get_file_include_paths(File) ++
-		        get_include_paths_from_rebar_config(File),
-    Paths = lists:filter(fun filelib:is_dir/1, Candidates),
-    gen_lsp_server:lsp_log("get_include_path: ~p", [Paths]),
-    Paths.
-
-get_standard_include_paths() ->
-    RootDir = gen_lsp_config_server:root(),
-    [
-        filename:join([RootDir, "_build", "default", "lib"]),
-        filename:join([RootDir, "_build", "default", "plugins"]),
-        filename:join([RootDir, "apps"]),
-        filename:join([RootDir, "lib"])
-    ].
-
-get_settings_include_paths() ->
-    SettingPaths = gen_lsp_config_server:includePaths(),
-    RootDir = gen_lsp_config_server:root(),
-    lists:map(fun (Path) -> 
-        abspath(RootDir, Path) 
-    end, SettingPaths).
-
-get_file_include_paths(File) ->
-    Paths = [filename:dirname(File), filename:rootname(File)],
-    case get_file_include_directory(File) of
-        undefined -> 
-            Paths;
-        Path -> 
-            [Path|Paths]
-    end.
-
-get_file_include_directory(File) ->
-    case lists:reverse(filename:split(filename:dirname(File))) of
-        [DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
-	        filename:join(lists:reverse(["include"|Rest]));
-        [_, DirName|Rest] when DirName =:= "src" orelse DirName =:= "test" ->
-	        filename:join(lists:reverse(["include"|Rest]));
-        _Other -> 
-            undefined
-    end.
-
-get_define_from_rebar_config(File) ->
-    RebarConfig = find_rebar_config(filename:dirname(File)),
-    case RebarConfig of
-        undefined -> 
-            [];
-        _ ->
-	        Consult = file:consult(RebarConfig),
-	        ErlOptsDefines = case Consult of
-			    {ok, Terms} ->
-				ErlOpts = proplists:get_value(erl_opts, Terms, []),
-				 Defines = rebar_define_to_epp_define(proplists:lookup_all(d, ErlOpts)),
-				 gen_lsp_server:lsp_log("get_defines: ~p", [Defines]),
-				 Defines;
-			     _ -> 
-                     []
-			   end,
-	  DefaultDefines = [],
-	  ErlOptsDefines ++ DefaultDefines
-    end.
-
-rebar_define_to_epp_define([]) -> 
-    [];
-rebar_define_to_epp_define([none]) -> 
-    [];
-rebar_define_to_epp_define([H|T]) ->
-    case H of
-      {d, Atom, Value} -> [{Atom, Value}] ++ rebar_define_to_epp_define(T);
-      {d, Atom} -> [Atom] ++ rebar_define_to_epp_define(T);
-      _ -> rebar_define_to_epp_define(T)
-    end.
-
-get_include_paths_from_rebar_config(File) ->
-    RebarConfig = find_rebar_config(filename:dirname(File)),
-    case RebarConfig of
-      undefined ->
-          [];
-      _ ->
-	  Consult = file:consult(RebarConfig),
-	  ErlOptsPaths = case Consult of
-			   {ok, Terms} ->
-			       ErlOpts = proplists:get_value(erl_opts, Terms, []),
-			       IncludePaths = proplists:get_all_values(i, ErlOpts),
-			       lists:map(fun (Path) ->
-						 filename:absname(Path, filename:dirname(RebarConfig))
-					 end, IncludePaths);
-			   _ -> 
-                   []
-			 end,
-        Deps = [],
-        %TODO: if include of each rebar dependency should be add to include paths, uncomment below 
-    %   Deps = case Consult of
-    %       {ok, DepsTerms} ->
-    %         Profiles = proplists:get_value(profiles, DepsTerms, []),
-    %         ErlDeps = lists:flatmap(fun({_,Opts})-> proplists:get_value(deps,Opts) end, Profiles),
-    %         RootDir = gen_lsp_config_server:root(),
-    %         [filename:join([RootDir, "_build", "default", "plugins", X, "include"]) || X <- ErlDeps ];
-    %       _ -> 
-    %         []
-    %       end,
-	  DefaultPaths = [filename:dirname(RebarConfig), filename:join([filename:dirname(RebarConfig), "include"])],
-	  ErlOptsPaths ++ Deps ++ DefaultPaths
-    end.
-
-find_rebar_config(Dir) ->
-    RebarConfig = filename:join(Dir, "rebar.config"),
-    case filelib:is_file(RebarConfig) of
-      true ->
-          RebarConfig;
-      _ ->
-	  Elements = filename:split(Dir),
-	  case Elements of
-	    [_] ->
-            undefined;
-	    _ ->
-		find_rebar_config(filename:join(lists:droplast(Elements)))
-	  end
-    end.
-
-abspath(BaseDir, Path) ->
-    case filename:pathtype(Path) of
-        relative ->
-            filename:absname_join(BaseDir, Path);
-        _ ->
-            Path
-    end.
-
-
 parse_transform(FileSyntaxTree, undefined) -> FileSyntaxTree;
 parse_transform(FileSyntaxTree, Transformers) ->
     lists:foldl(fun(M, Syntax) -> 
@@ -348,7 +127,6 @@ parse_transform(FileSyntaxTree, Transformers) ->
         end, 
     FileSyntaxTree, Transformers).
     %FileSyntaxTree.
-
 
 lint(FileSyntaxTree, File) ->
     LintResult = case lsp_utils:is_erlang_lib_file(File) of

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -7,7 +7,8 @@
          search_exclude_globs_to_regexps/1,
          to_string/1,
          is_erlang_lib_file/1,
-         absolute_path/2]).
+         absolute_path/2,
+         make_temporary_file/1]).
 
 client_range(Line, StartChar, EndChar) ->
     #{
@@ -221,3 +222,10 @@ absolute_path(BaseDir, Path) ->
         _ ->
             Path
     end.
+
+make_temporary_file(Contents) ->
+    Rand = integer_to_list(binary:decode_unsigned(crypto:strong_rand_bytes(8)), 36) ++ ".erl",
+    TempFile = filename:join(gen_lsp_config_server:tmpdir(), Rand),
+    filelib:ensure_dir(TempFile),
+    file:write_file(TempFile, Contents),
+    TempFile.

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -225,7 +225,10 @@ absolute_path(BaseDir, Path) ->
 
 make_temporary_file(Contents) ->
     Rand = integer_to_list(binary:decode_unsigned(crypto:strong_rand_bytes(8)), 36) ++ ".erl",
-    TempFile = filename:join(gen_lsp_config_server:tmpdir(), Rand),
+    TempFile = case gen_lsp_config_server:tmpdir() of
+        "" -> Rand;
+        TmpDir -> filename:join(TmpDir, Rand)
+    end,
     filelib:ensure_dir(TempFile),
     file:write_file(TempFile, Contents),
     TempFile.

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -6,7 +6,8 @@
          is_path_excluded/2,
          search_exclude_globs_to_regexps/1,
          to_string/1,
-         is_erlang_lib_file/1]).
+         is_erlang_lib_file/1,
+         absolute_path/2]).
 
 client_range(Line, StartChar, EndChar) ->
     #{
@@ -207,9 +208,16 @@ do_is_path_excluded(Path, [{RegExp, true} | ExcFilters], PreliminaryAnswer) ->
         nomatch    -> do_is_path_excluded(Path, ExcFilters, PreliminaryAnswer)
     end.
 
-
 is_erlang_lib_file(File) ->
     case string_prefix(File, code:lib_dir()) of
         nomatch -> false;
         _ -> true
+    end.
+
+absolute_path(BaseDir, Path) ->
+    case filename:pathtype(Path) of
+        relative ->
+            filename:absname_join(BaseDir, Path);
+        _ ->
+            Path
     end.

--- a/apps/erlangbridge/src/vscode_lsp_entry.erl
+++ b/apps/erlangbridge/src/vscode_lsp_entry.erl
@@ -31,7 +31,7 @@ compile_needed_modules() ->
         "src/gen_lsp_sup", "src/gen_lsp_doc_sup","src/gen_lsp_doc_server", "src/gen_lsp_config_sup","src/gen_lsp_config_server",
         "src/gen_lsp_help_sup","src/gen_lsp_help_server", "src/lsp_handlers", "src/lsp_utils",
         "src/vscode_lsp_app_sup", "src/lsp_navigation", "src/lsp_parse", "src/lsp_syntax", "src/lsp_completion",
-        "src/gen_connection", "src/vscode_jsone","src/vscode_jsone_decode","src/hover_doc_layout", "src/worker.erl"], CompileOptions)
+        "src/gen_connection", "src/vscode_jsone","src/vscode_jsone_decode","src/hover_doc_layout", "src/worker"], CompileOptions)
     .
 
 do_compile([H|T], CompileOptions) ->

--- a/apps/erlangbridge/src/vscode_lsp_entry.erl
+++ b/apps/erlangbridge/src/vscode_lsp_entry.erl
@@ -30,7 +30,7 @@ compile_needed_modules() ->
     do_compile(["src/vscode_lsp_app", "src/gen_lsp_server", 
         "src/gen_lsp_sup", "src/gen_lsp_doc_sup","src/gen_lsp_doc_server", "src/gen_lsp_config_sup","src/gen_lsp_config_server",
         "src/gen_lsp_help_sup","src/gen_lsp_help_server", "src/lsp_handlers", "src/lsp_utils",
-        "src/vscode_lsp_app_sup", "src/lsp_navigation", "src/lsp_syntax", "src/lsp_completion",
+        "src/vscode_lsp_app_sup", "src/lsp_navigation", "src/lsp_parse", "src/lsp_syntax", "src/lsp_completion",
         "src/gen_connection", "src/vscode_jsone","src/vscode_jsone_decode","src/hover_doc_layout"], CompileOptions)
     .
 

--- a/apps/erlangbridge/src/vscode_lsp_entry.erl
+++ b/apps/erlangbridge/src/vscode_lsp_entry.erl
@@ -31,7 +31,7 @@ compile_needed_modules() ->
         "src/gen_lsp_sup", "src/gen_lsp_doc_sup","src/gen_lsp_doc_server", "src/gen_lsp_config_sup","src/gen_lsp_config_server",
         "src/gen_lsp_help_sup","src/gen_lsp_help_server", "src/lsp_handlers", "src/lsp_utils",
         "src/vscode_lsp_app_sup", "src/lsp_navigation", "src/lsp_parse", "src/lsp_syntax", "src/lsp_completion",
-        "src/gen_connection", "src/vscode_jsone","src/vscode_jsone_decode","src/hover_doc_layout"], CompileOptions)
+        "src/gen_connection", "src/vscode_jsone","src/vscode_jsone_decode","src/hover_doc_layout", "src/worker.erl"], CompileOptions)
     .
 
 do_compile([H|T], CompileOptions) ->

--- a/apps/erlangbridge/src/worker.erl
+++ b/apps/erlangbridge/src/worker.erl
@@ -1,0 +1,25 @@
+-module(worker).
+-export([start/2]).
+
+-define(KILL_AFTER, 10 * 60000).
+
+start(Fun, ID) ->
+    Owner = self(),
+    spawn_link(fun () ->
+        {Worker, Monitor} = spawn_monitor(fun () ->
+            try
+                erlang:send(Owner, {worker_result, ID, Fun()})
+            catch _Class:Exception:Stack ->
+                logger:error("~p", [Stack]),
+                erlang:send(Owner, {worker_error, ID, Exception})
+            end
+        end),
+        receive
+            {'DOWN', Monitor, process, Worker, _Reason} -> ok
+        after
+            ?KILL_AFTER ->
+                logger:error("Worker ~p killed due to timeout", [Worker]),
+                exit(Worker, kill),
+                erlang:send(Owner, {worker_error, ID, timeout})
+        end
+    end).

--- a/apps/erlangbridge/test/lsp_navigation_SUITE.erl
+++ b/apps/erlangbridge/test/lsp_navigation_SUITE.erl
@@ -55,7 +55,7 @@ end_per_testcase(_TestCase, Config) ->
 
 parseFile(AppDir, [FileName | T]) ->
     FilePath = filename:join(AppDir, FileName),
-    lsp_syntax:parse_source_file(FilePath, FilePath),
+    lsp_parse:parse_source_file(FilePath, FilePath),
     parseFile(AppDir, T);
 parseFile(_AppDir, []) -> ok.
 

--- a/apps/erlangbridge/test/lsp_navigation_SUITE.erl
+++ b/apps/erlangbridge/test/lsp_navigation_SUITE.erl
@@ -86,17 +86,17 @@ dotestfiles(_AppDir, []) ->
     ok.
 
 dotestfile(FilePath, [{Line,Column, ExpectedLine, _ExpectedColumn, ExpectedModuleName}|T]) ->
-    GoTo = lsp_navigation:goto_definition(FilePath, Line,Column),
+    GoTo = lsp_navigation:definition(FilePath, Line,Column),
     ?writeConsole(GoTo),
     check_result(GoTo, ExpectedLine, ExpectedLine, ExpectedModuleName),
     dotestfile(FilePath, T);  
 dotestfile(FilePath, [{Line,Column, ExpectedLine, _ExpectedColumn}|T]) ->
-    GoTo = lsp_navigation:goto_definition(FilePath, Line,Column),
+    GoTo = lsp_navigation:definition(FilePath, Line,Column),
     ?writeConsole(GoTo),
     check_result(GoTo, ExpectedLine, ExpectedLine),
     dotestfile(FilePath, T);  
 dotestfile(FilePath, [{Line,Column, ExpectedLine}|T]) ->
-    GoTo = lsp_navigation:goto_definition(FilePath, Line,Column),
+    GoTo = lsp_navigation:definition(FilePath, Line,Column),
     ?writeConsole(GoTo),
     check_result(GoTo, ExpectedLine, ExpectedLine),
     dotestfile(FilePath, T);  

--- a/apps/erlangbridge/test/lsp_navigation_SUITE.erl
+++ b/apps/erlangbridge/test/lsp_navigation_SUITE.erl
@@ -54,29 +54,18 @@ end_per_testcase(_TestCase, Config) ->
 %%%%%%%%%%%%%%%%
 
 check_result(Result, ExpectedStart, ExpectedEnd, ExpectedModuleName) ->
-    #{range := #{<<"end">> := #{line := EndLine}, 
-        <<"start">> := #{line := StartLine}},
-      uri := FilePath} = Result,
-    ?assertEqual(ExpectedStart, StartLine),
-    ?assertEqual(ExpectedEnd, EndLine),
-    BaseName = filename:basename(binary_to_list(FilePath)),
+    error_logger:info_msg("check_result: ~p ~p ~p ~p~n", [Result, ExpectedStart, ExpectedEnd, ExpectedModuleName]),
+    {FilePath, Line, _StartColumn, _EndColumn} = Result,
+    ?assertEqual(ExpectedStart, Line - 1),
+    ?assertEqual(ExpectedEnd, Line - 1),
+    BaseName = filename:basename(FilePath),
     ?assertEqual(ExpectedModuleName, BaseName).
 
-
 check_result(Result, ExpectedStart, ExpectedEnd) ->
-    #{range := #{<<"end">> := #{line := EndLine}, 
-        <<"start">> := #{line := StartLine}}} = Result,
+    {_File, Line, _StartColumn, _EndColumn} = Result,
 
-    ?assertEqual(ExpectedStart, StartLine),
-    ?assertEqual(ExpectedEnd, EndLine),
-    % sample result    
-    % A = #{range =>
-    %           #{<<"end">> => #{character => 0, line => 17},
-    %             <<"start">> => #{character => 0, line => 17}},
-    %       uri =>
-    %           <<"file:///...../sources/vscode"
-    %             "_erlang/_build/test/lib/vscode_lsp/test/lsp_n"
-    %             "avigation_SUITE_data/main.erl">>},
+    ?assertEqual(ExpectedStart, Line - 1),
+    ?assertEqual(ExpectedEnd, Line - 1),
     ok.
 
 dotestfiles(AppDir, [{FileName, LocationTests}|T]) ->
@@ -86,12 +75,12 @@ dotestfiles(_AppDir, []) ->
     ok.
 
 dotestfile(FilePath, [{Line,Column, ExpectedLine, _ExpectedColumn, ExpectedModuleName}|T]) ->
-    GoTo = lsp_navigation:definition(FilePath, Line,Column),
+    GoTo = lsp_navigation:definition(FilePath, Line, Column),
     ?writeConsole(GoTo),
     check_result(GoTo, ExpectedLine, ExpectedLine, ExpectedModuleName),
     dotestfile(FilePath, T);  
 dotestfile(FilePath, [{Line,Column, ExpectedLine, _ExpectedColumn}|T]) ->
-    GoTo = lsp_navigation:definition(FilePath, Line,Column),
+    GoTo = lsp_navigation:definition(FilePath, Line, Column),
     ?writeConsole(GoTo),
     check_result(GoTo, ExpectedLine, ExpectedLine),
     dotestfile(FilePath, T);  

--- a/apps/erlangbridge/test/lsp_navigation_SUITE.erl
+++ b/apps/erlangbridge/test/lsp_navigation_SUITE.erl
@@ -53,12 +53,6 @@ end_per_testcase(_TestCase, Config) ->
 %% test cases %%
 %%%%%%%%%%%%%%%%
 
-parseFile(AppDir, [FileName | T]) ->
-    FilePath = filename:join(AppDir, FileName),
-    lsp_parse:parse_source_file(FilePath, FilePath),
-    parseFile(AppDir, T);
-parseFile(_AppDir, []) -> ok.
-
 check_result(Result, ExpectedStart, ExpectedEnd, ExpectedModuleName) ->
     #{range := #{<<"end">> := #{line := EndLine}, 
         <<"start">> := #{line := StartLine}},

--- a/lib/lsp/lspclientextension.ts
+++ b/lib/lsp/lspclientextension.ts
@@ -93,6 +93,10 @@ namespace Configuration {
           client.sendNotification(DidChangeWatchedFilesNotification.type,
             { changes: [{ uri: uri.fsPath, type: FileChangeType.Created }] });
         });
+        fileSystemWatcher.onDidChange(uri => {
+          client.sendNotification(DidChangeWatchedFilesNotification.type,
+            { changes: [{ uri: uri.fsPath, type: FileChangeType.Changed }] });
+        });
         fileSystemWatcher.onDidDelete(uri => {
           client.sendNotification(DidChangeWatchedFilesNotification.type,
             { changes: [{ uri: uri.fsPath, type: FileChangeType.Deleted }] });


### PR DESCRIPTION
Most of navigation code has been rewritten or refactored. Major changes:
- All project source files are parsed after project is opened
- References work within the project not only locally in single file
- References work for variables
- Code Lens show references in the project not only local
- Some fixes in completion of record field names
- Outline shows functions as functions not constructors