### PR TITLE
Fix Go to definition at record name and field (#263)

### DIFF
--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -438,14 +438,14 @@ find_definition(File, {{gen_msg, GenMsg}, _Details}) ->
 find_definition(File, {{_, {record, Record}}, _Details}) ->
     find_in_syntax_tree(fun
         ({attribute, {L, Start}, record, {FoundRecord, _}}, CurrentFile) when Record =:= FoundRecord ->
-            {CurrentFile, L, Start, Start};
+            {lsp_utils:to_string(CurrentFile), L, Start, Start};
         (_SyntaxTree, _CurrentFile) ->
             undefined
     end, File);
 find_definition(File, {{_, {field, Record, Field}}, _Details}) ->
     find_in_syntax_tree(fun
         ({attribute, _, record, {FoundRecord, Fields}}, CurrentFile) when Record =:= FoundRecord ->
-            find_field_definition(Field, Fields, CurrentFile);
+            find_field_definition(Field, Fields, lsp_utils:to_string(CurrentFile));
         (_SyntaxTree, _CurrentFile) ->
             undefined
     end, File);


### PR DESCRIPTION
Accept file path of record definition in both string and binary format when looking for definition.

I am not sure exactly since when and why but it seems 'epp' returns file names in record attributes as binaries instead of strings for a while. Let's always convert it to string.