### PR TITLE
Fine tuning of scannig for project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Support for Erlang tools, including rebar3, EUnit and Dialyzer
 ## Settings
 
 - `erlang.erlangPath` - Directory location of erl/escript
+- `erlang.erlangArgs` - Arguments passed to Erlang backend
+- `erlang.erlangDistributedNode` - Start the Erlang backend in a distributed Erlang node for extension development
 - `erlang.rebarPath` - Directory location of rebar/rebar3
 - `erlang.rebarBuildArgs` - Arguments to provide to rebar/rebar3 build command
 - `erlang.includePaths` - Include paths are read from rebar.config, and also standard set of paths is used. This setting is for special cases when the default behaviour is not enough

--- a/apps/erlangbridge/src/gen_lsp_config_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_config_server.erl
@@ -5,9 +5,9 @@
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 -export([standard_modules/0, bifs/0]).
--export([update_config/2, root/0, tmpdir/0, codeLensEnabled/0, includePaths/0, linting/0, 
-        verbose/0, autosave/0, proxy/0, search_exclude/0, formatting_line_length/0,
-        inlayHintsEnabled/0]).
+-export([update_config/2, root/0, tmpdir/0, codeLensEnabled/0, includePaths/0, linting/0,
+        verbose/0, autosave/0, proxy/0, search_files_exclude/0, search_exclude/0,
+        formatting_line_length/0, inlayHintsEnabled/0]).
 
 -define(SERVER, ?MODULE).
 
@@ -59,8 +59,40 @@ proxy() ->
 tmpdir() ->
     get_config_entry(computed, tmpdir, "").
 
+%%--------------------------------------------------------------------
+%% @doc Exclude filters for search in workspace.
+%%
+%% It is a combination of Visual Studio Code settings `files.exclude' and
+%% `search.exclude' as Visual Studio Code GUI does merge these for searching
+%% but extensions get the pure settings and we have to merge them explicitly.
+%% @end
+%%--------------------------------------------------------------------
 search_exclude() ->
-    get_config_entry(search, exclude, #{}).
+    %% From https://code.visualstudio.com/docs/getstarted/settings
+    %% files.exclude:
+    %%   Configure glob patterns for excluding files and folders. For example,
+    %%   the File Explorer decides which files and folders to show or hide based
+    %%   on this setting. Refer to the `search.exclude` setting to define
+    %%   search-specific excludes.
+    %% search.exclude:
+    %%   Configure glob patterns for excluding files and folders in fulltext
+    %%   searches and quick open. Inherits all glob patterns from the
+    %%   `files.exclude` setting.
+    maps:merge(get_config_entry(files, exclude, #{}),
+               get_config_entry(search, exclude, #{})).
+
+%%--------------------------------------------------------------------
+%% @doc Exclude filters for searching project files.
+%%
+%% It is a combination of Visual Studio Code settings `files.exclude',
+%% `files.watcherExclude' and `search.exclude'.
+%% @end
+%%--------------------------------------------------------------------
+search_files_exclude() ->
+    %% From https://code.visualstudio.com/docs/getstarted/settings
+    %% files.watcherExclude:
+    %%   Configure paths or glob patterns to exclude from file watching.
+    maps:merge(get_config_entry(files, watcherExclude, #{}), search_exclude()).
 
 formatting_line_length() ->
     get_config_entry(erlang, formattingLineLength, 100).

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -158,10 +158,15 @@ glob_wo_alternatives_to_regexp("*" ++ Chars) ->
     ["[^/]*" | glob_wo_alternatives_to_regexp(Chars)];
 glob_wo_alternatives_to_regexp("?" ++ Chars) ->
     ["[^/]" | glob_wo_alternatives_to_regexp(Chars)];
+%% Escape plain glob characters that have special meaning in regular expression
+glob_wo_alternatives_to_regexp("." ++ Chars) ->
+    ["\\." | glob_wo_alternatives_to_regexp(Chars)];
+%% Ordinary character
 glob_wo_alternatives_to_regexp([Char | Chars]) ->
     [Char | glob_wo_alternatives_to_regexp(Chars)].
 
-%% Translate glob alternations to regular expression alternations
+%% Translate glob alternations to regular expression alternations.
+%% `{Item1,...}' -> `(Item1|...)'
 -spec glob_alternations_to_regexp(Glob :: string()) -> RegExp :: string().
 glob_alternations_to_regexp(Glob) ->
     RE = "^(.*)\\{([^{}]+,[^{}]+)\\}(.*)$",

--- a/apps/erlangbridge/test/lsp_navigation_SUITE.erl
+++ b/apps/erlangbridge/test/lsp_navigation_SUITE.erl
@@ -126,6 +126,7 @@ testnavigation(Config) ->
     gen_lsp_config_server:update_config(root, AppDir),
     % add all documents from root dir into documents server
     gen_lsp_doc_server:root_available(),
+    gen_lsp_doc_server:config_change(),
     dotestfiles(AppDir, navigation_datatests()),
     ok.
 

--- a/lib/ErlangConfigurationProvider.ts
+++ b/lib/ErlangConfigurationProvider.ts
@@ -26,6 +26,8 @@ export function configurationChanged() : void {
     let erlangConf = workspace.getConfiguration("erlang");
     let settings : ErlangSettings = {
         erlangPath: erlangConf.get<string>("erlangPath", null),
+        erlangArgs: erlangConf.get("erlangArgs", []),
+        erlangDistributedNode: erlangConf.get("erlangDistributedNode", false),
         rebarPath: erlangConf.get<string>("rebarPath", null),
         codeLensEnabled: erlangConf.get<boolean>('codeLensEnabled', false),
         inlayHintsEnabled: erlangConf.get<boolean>('inlayHintsEnabled', false),

--- a/lib/GenericShell.ts
+++ b/lib/GenericShell.ts
@@ -37,6 +37,8 @@ export class GenericShell extends EventEmitter {
     protected buffer: string = "";
     protected errbuf: string = "";
     public erlangPath: string = null;
+	public erlangArgs : string[] = [];
+	public erlangDistributedNode: boolean = false;
 
     //provide IGenericShellConfiguration, in order to avoid dependencies on vscode module (it doesn't works with debugger-adpater)
     constructor(logOutput?: ILogOutput, shellOutput?: IShellOutput, erlangConfiguration?: ErlangSettings) {
@@ -44,8 +46,8 @@ export class GenericShell extends EventEmitter {
         this.logOutput = logOutput;
         this.shellOutput = shellOutput;
 
-        // Find Erlang 'bin' directory
         if (erlangConfiguration) {
+            // Find Erlang 'bin' directory
             let erlangPath = erlangConfiguration.erlangPath;
             if (erlangPath) {
                 if (erlangPath.match(/^[A-Za-z]:/)) {
@@ -63,6 +65,8 @@ export class GenericShell extends EventEmitter {
                     }
                 }
             }
+            this.erlangArgs = erlangConfiguration.erlangArgs;
+            this.erlangDistributedNode = erlangConfiguration.erlangDistributedNode;
         }
     }
 

--- a/lib/erlangSettings.ts
+++ b/lib/erlangSettings.ts
@@ -1,5 +1,7 @@
 export interface ErlangSettings {
 	erlangPath : string;
+	erlangArgs : string[];
+	erlangDistributedNode: boolean;
 	rebarPath : string;
 	rebarBuildArgs : string[];
 	includePaths : string[];

--- a/lib/lsp/ErlangShellLSP.ts
+++ b/lib/lsp/ErlangShellLSP.ts
@@ -6,10 +6,24 @@ export class ErlangShellLSP extends GenericShell {
         super(whichOutput, null, getElangConfigConfiguration());
     }
     public Start(erlPath:string, startDir: string, listen_port: number, bridgePath: string, args: string): Promise<boolean> {
-        //var debugStartArgs = ["-pa", `"${bridgePath}"`, "-pa", "ebin", "-s", "int",
-        var debugStartArgs = ["-noshell", "-pa", "src", "-pa", "ebin", "-s", "int",
+        var debugStartArgs = [];
+        // Start as distributed node to be able to connect to the Erlang VM for investigation
+        if (this.erlangDistributedNode) {
+            debugStartArgs.push(
+                "-sname", "vscode_" + listen_port.toString(),
+                "-setcookie", "vscode_" + listen_port.toString());
+        }
+        // Use special command line arguments
+        if (this.erlangArgs) {
+            debugStartArgs = debugStartArgs.concat(this.erlangArgs)
+        }
+        debugStartArgs.push(
+            "-noshell",
+            "-pa", "src",
+            "-pa", "ebin",
+            "-s", "int",
             "-vscode_port", listen_port.toString(),
-            "-s", "vscode_lsp_entry", "start", listen_port.toString()];
+            "-s", "vscode_lsp_entry", "start", listen_port.toString());
         var processArgs = debugStartArgs.concat([args]);
 
         var result = this.LaunchProcess("erl", startDir, processArgs);

--- a/lib/lsp/lspclientextension.ts
+++ b/lib/lsp/lspclientextension.ts
@@ -245,7 +245,6 @@ export function activate(context: ExtensionContext) {
 		return new Promise<StreamInfo>(async (resolve, reject) => {
 			await compileErlangBridge(context.extensionPath);
 			let erlangLsp = new ErlangShellLSP(ErlangOutputAdapter(lspOutputChannel));
-			erlangLsp.erlangPath = erlangCfg.erlangPath;
 
 			getPort(async function (port) {
 				erlangLsp.Start("", erlangBridgePath, port, "src", "");

--- a/package.json
+++ b/package.json
@@ -165,6 +165,21 @@
 					"default": "",
 					"description": "Directory where erl/escript are located. Leave empty to use default."
 				},
+				"erlang.erlangArgs": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"title": "argument",
+						"default": ""
+					},
+					"default": [],
+					"description": "Arguments passed to Erlang backend. Leave empty unless you really have to tweak the Erlang VM."
+				},
+				"erlang.erlangDistributedNode": {
+					"type": "boolean",
+					"description": "Start the Erlang backend in a distributed Erlang node. Could be usefull for extension development. Note, it starts EPMD if not running yet.",
+					"default": false
+				},
 				"erlang.rebarPath": {
 					"type": "string",
 					"default": "",


### PR DESCRIPTION
### Issue

In our project we noticed huge resource usage of the extension, it constantly used 1-2 CPU cores and consumed more and more memory and eventually used all the free memory that pretty much paralyzed the system until the process died (crashed?). After some investigation (see commit b0ae632) the root cause was identified.

Our project doesn't use Rebar3 but Bazel that uses sand boxed environments to build targets and sym-links to connect pieces of the repository and used tools in the sandbox. Therefore, original source files are linked from the sandbox directories as well as Erlang/OTP files and the extension find all of these files as many times as many sandbox directory were linked in the build cache directory. In result, Erlang/OTP copies were parsed and loaded into memory continuously until there were any free memory.

### Solution

Visual Studio Code have exclude filters to limit search targets (combination of `search.exclude` and `files.exclude`), hide (generated?) files in the Explorer window (`files.exclude`) and don't watch for file changes (`files.watcherExclude`) [1].  We can use these filters when scanning the workspace for project files as usually those files and directories are listed there that are generated by the build system.

> Note:
> This idea is already used in the extension by the _"Go to definition"_ feature to select among multiple source files however only `search.exclude` was used there before. Actually, Visual Studio Code GUI combines `search.exclude` and `files.exclude` when search in the workspace but extensions get the pure, uncombined settings so the extensions need to combine them. And in addition, I think it's a good idea to use `files.watcherExclude` as well for finding source files. (see commit 6b69d3f)

### Reproduction

Prepare a sample project: (using linux and bash)

```bash
rebar3 new lib myproj
mkdir -p myproj/exotic_build_dir/test_run_1
cd myproj/exotic_build_dir
ln -s ../src src
cd test_run_1
ln -s "$(dirname "$(dirname "$(which erl)")")" otp
cd ../..
mkdir .vscode
```

Edit `.vscode/settings.json` as below:

```json
{
    "search.exclude": {
        "exotic_build_dir": true
    },
    "erlang.verbose": true
}
```

Add `jsx` to the `deps` list in `rebar.config` just to have any dependency.

Edit myproj.erl as below:

```erlang
-module(myproj).

-export([f/0]).

f() ->
    jsx:encode([]).
```

In result we get something like below:

```text
/tmp/x/myproj
├── exotic_build_dir
│   ├── src -> ../src
│   └── test_run_1
│       └── otp -> <__path_to_your_Erlang_OTP_installation__>
├── .gitignore
├── LICENSE
├── README.md
├── rebar.config
├── src
│   ├── myproj.app.src
│   └── myproj.erl
└── .vscode
    └── settings.json
```

**With extension version 0.9.3:**

Open the project folder in VSC and open file `myproj.erl`.

Go to menu _"View > Output"_, choose _"Erlang Language Server"_ and check as the extension finds and parses
`exotic_build_dir/src/myproj.erl` and Erlang/OTP files through `exotic_build_dir/test_run_1/otp` sym-link.

Let's assume there are many `test_run_*` directories under `exotic_build_dir` and all of them links to Erlang/OTP. In this case the extension parses OTP many times that easily consumes all the available memory. :(

**With commits of this pull request:**

Open the project folder in VSC and open file `myproj.erl`.

Go to menu _"View > Output"_, choose _"Erlang Language Server"_ and check as the extension parses only one file, `src/myproj.erl`.

Edit `.vscode/settings.json` and modify the exclude pattern as below and save it:

```json
    "search.exclude": {
        "exotic_build_dir/test_run_*": true
    },
```

Check _"Erlang Language Server"_ output again to see how `exotic_build_dir/src/myproj.erl` is parsed.

Revert the previous change in `.vscode/settings.json`, save it and check _"Erlang Language Server"_ output again to see how `exotic_build_dir/src/myproj.erl` is removed among of the project files (deleted from navigation DB).

Finally, let's check if it is still compatible to Rebar3.

Run command `rebar3 compile`. As the extension doesn't actively looking for new project source files, no activity in _"Erlang Language Server"_ output window. To trigger the extension, edit `.vscode/settings.json` by e.g. add a new dummy `search.exclude` pattern.

Check the _"Erlang Language Server"_ output window again to see how the extension finds file `_build/default/myproj/src/myproj.erl` but decides to ignore it as it is a duplication by Rebar3, not the original source file. In the same time, although `_build/default/myproj/src/myproj.erl` is ignored but `_build/default/lib/jsx/src/*.erl` files are kept to be parsed as those are the original files of the 3PP.

Open `myproj.erl`, go to function definition `f/0` and use feature "Go to definition" at `jsx:encode`.

[1] https://code.visualstudio.com/docs/getstarted/settings