### PR TITLE
Navigation updates

### DIFF
--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -124,15 +124,11 @@ textDocument_definition(_Socket, Params) ->
     Uri = mapmapget(textDocument, uri, Params),
     Line = mapmapget(position, line, Params),
     Character = mapmapget(position, character, Params),
-    case lsp_navigation:definition(lsp_utils:file_uri_to_file(Uri), Line + 1, Character + 1) of
-        {File, L, S, E} ->
-            #{
-                uri => lsp_utils:file_uri_to_vscode_uri(lsp_utils:file_to_file_uri(File)),
-                range => lsp_utils:client_range(L, S, E)
-            };
-        undefined ->
-            []
-    end.
+    Locations = lsp_navigation:definition(lsp_utils:file_uri_to_file(Uri), Line + 1, Character + 1),
+    [#{uri => lsp_utils:file_uri_to_vscode_uri(lsp_utils:file_to_file_uri(File)),
+       range => lsp_utils:client_range(L, S, E)
+     }
+     || {File, L, S, E}<-Locations].
 
 textDocument_references(_Socket, Params) ->
     Uri = mapmapget(textDocument, uri, Params),

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -44,10 +44,14 @@ file_uri_to_vscode_uri(Uri) ->
       _ -> EncodeUri
     end.
 
+file_to_file_uri(<<"//", BinFile/binary>>) ->
+    <<"file://", BinFile/binary>>;
 file_to_file_uri("//" ++ File) ->
     BinFile = list_to_binary(File),
     <<"file://", BinFile/binary>>;
-file_to_file_uri(File) ->
+file_to_file_uri(BinFile) when is_binary(BinFile) ->
+    <<"file://", BinFile/binary>>;
+file_to_file_uri(File) when is_list(File) ->
     BinFile = list_to_binary(File),
     <<"file://", BinFile/binary>>.
 


### PR DESCRIPTION
Normally there are no multiple source (`*.erl`) or header (`*.hrl`) files present in a project with the same name. However it is possible to create files with the same name under different paths with different content. For example if a project has multiple build targets and slightly different implementation or definition is needed for the different targets. In this case it would be nice to locate all the definitions and the user could choose the correct one (depending on the build target that he or she is working with currently).

Let's always return a list of locations for `textDocument/definition` requests.

### Prepare sample project

Create a new rebar3 project (in Linux and Bash):

```bash
rebar3 new lib navigation
mkdir -p include/build_target_1
mkdir -p include/build_target_2
mkdir -p src/build_target_1
mkdir -p src/build_target_2
```

Create `include/build_target_1/myheader.hrl`:

```erlang
-define(BUILD_TARGET, 1).

-record(foo,
        {build_target = ?BUILD_TARGET,
         file = ?FILE,
         a = 1 :: integer(), % a
         b = 2 :: integer(),
         c = "c", % c
         d = "d",
         e :: integer(), % e
         f :: integer(),
         g, % g
         h
        }).
%% My foo record for build target 1
```

Create `include/build_target_1/myheader.hrl`:

```erlang
-define(BUILD_TARGET, 2).

-record(foo,
        {build_target = ?BUILD_TARGET,
         file = ?FILE,
         a = 101 :: integer(), % a
         b = 102 :: integer(),
         c = "C", % c
         d = "D",
         e :: integer(), % e
         f :: integer(),
         g, % g
         h
        }).
%% My foo record for build target 1
```

Create `src/build_target_1/mylib.erl`

```erlang
%%% @doc My library for build target 1
-module(mylib).

-export([f/0]).

-include("myheader.hrl").

%% @doc My library function for build target 1
-spec f() -> integer().
f() ->
    ?BUILD_TARGET.
```

Create `src/build_target_2/mylib.erl`

```erlang
%%% @doc My library for build target 1
-module(mylib).

-export([f/0]).

-include("myheader.hrl").

%% @doc My library function for build target 2
-spec f() -> string().
f() ->
    integer_to_list(?BUILD_TARGET).
```

Update `src/navigation.erl`:

```erlang
-module(navigation).

-export([f/0]).

-include("myheader.hrl").
-include_lib("kernel/include/logger.hrl").

f() ->
    ?LOG_INFO("Hello World!"),
    io:format("Build target ~p~n", [?BUILD_TARGET]),
    io:format("Build target dependent default record 'foo': ~p~n", [#foo{}]),
    Foo = #foo{a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h = 8},
    g(Foo#foo{a = a, b = b, c = c, d = d, e = e, f = f, g = g, h = h}),
    cts:new(),
    mylib:f().

g(#foo{build_target = Target, file = File, a = A, b = B, c = C, d = D, e = E, f = F, g = G, h = H}) ->
    Props = lists:zip(record_info(fields, foo), [Target, File, A, B, C, D, E, F, G, H]),
    io:format("Record 'foo' as property list: ~p~n", [Props]).
```

Update `navigation.app.src`:

```erlang
{application, navigation,
 [{description, "An OTP library"},
  {vsn, "0.1.0"},
  {registered, []},
  {applications,
   [kernel,
    stdlib
   ]},
  {env,[]},
  {modules, [navigation, ctx]},

  {licenses, ["Apache-2.0"]},
  {links, []}
 ]}.
```

Configure rebar3 in `rebar.config`:

```erlang
{erl_opts, [debug_info]}.
{deps, [ctx]}.
{profiles, [
    {build_target_1, [
        {erl_opts, [
            {i, "include/build_target_1"},
            {i, "include"},
            {src_dirs, [
                "src/build_target_1",
                {"src", [{recursive, false}]}
            ]}
        ]}
    ]},
    {build_target_2, [
        {erl_opts, [
            {i, "include/build_target_2"},
            {i, "include"},
            {src_dirs, [
                "src/build_target_2",
                {"src", [{recursive, false}]}
            ]}
        ]}
    ]}
]}.
```

Configure Visual Studio Code:

```json
{
    "erlang.includePaths": [
        "include/build_target_1",
        "include/build_target_2",
        "include"
    ],
    "erlang.verbose": true
}
```

### Exercises

Try to use "Go to definition" on below locations and observe the difference between the current and proposed behavior, jump to the first definition vs. offer all definitions to the user to choose from.

Open `src/navigation.erl`, place the cursor where character `|` is inserted in below code and hit F12 (or Ctrl-click).

```erlang
-module(navigation).

-export([f|/0]).

-inclu|de("myhe|ader.hrl").
-inclu|de_lib("ker|nel/include/logger.hrl").

f() ->
    ?LOG_INFO("Hello World!"),
    io:format("Build target ~p~n", [?BUILD_|TARGET]),
    io:format("Build target dependent default record 'foo': ~p~n", [#fo|o{}]),
    Foo = #fo|o{|a = 1, b| = 2, |c = 3, d| = 4, |e = 5, f| = 6, |g = 7, h| = 8},
    g(Foo#fo|o{|a = a, b| = b, |c = c, d| = d, |e = e, f| = f, |g = g, h| = h}),
    ct|x:n|ew(),
    myli|b:f|().

g(#fo|o{build_|target = Target, f|ile = File, |a = A, b| = B, |c = C, d| = D, |e = E, f| = F, |g = G, h| = H}) ->
    Props = lists:zip(record_info(fields, foo), [target, File, A, B, C, D, E, F, G, H]),
    io:format("Record 'foo' as property list: ~p~n", [Props]).
```

Similarly try to use "Go to defeinition" in e.g. `src/build_target_1.erl`:

```erlang
%%% @doc My library for build target 1
-module(mylib).

-export([f/0]).

-inclu|de("myhe|ader.hrl").

%% @doc My library function for build target 1
-spec f() -> integer().
f() ->
    ?BUILD_|TARGET.
```