### PR TITLE
IncludeFilesToVisit should include unvisited files

### DIFF
--- a/apps/erlangbridge/src/lsp_navigation.erl
+++ b/apps/erlangbridge/src/lsp_navigation.erl
@@ -534,8 +534,8 @@ find_definitions_in_files(Type, Name, [File | Files], VisitedFiles) ->
                                     || IncludedRelFile <- IncludedRelFiles,
                                        Dir <- IncludeDirs] ++ Files,
             IncludeFilesToVisit = [IncFile
-                                   || IncFile<-PossibleIncludeFiles,
-                                      not maps:is_key(File, VisitedFiles)],
+                                   || IncFile <- PossibleIncludeFiles,
+                                      not maps:is_key(IncFile, VisitedFiles)],
             find_definitions_in_files(Type, Name, IncludeFilesToVisit,
                                       VisitedFiles#{File => 1});
         Result ->


### PR DESCRIPTION
lsp_navigation:find_definitions_in_files/4 will travel all possible included files recursively, to avoid circular traversal, we create a visited map to track and skip the file visited files.