### PR TITLE
Search for and parse only Erlang source files

### DIFF
--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -271,7 +271,7 @@ scan_project_files(State = #state{project_modules = OldProjectModules}) ->
                 false -> do_add_project_file(File, AccProjectModules, BuildDir)
             end
         end,
-    AllProjectModules = filelib:fold_files(gen_lsp_config_server:root(), ".erl$",
+    AllProjectModules = filelib:fold_files(gen_lsp_config_server:root(), "\\.erl$",
                                            true, CollectProjSrcFilesFun, #{}),
     gen_lsp_server:lsp_log(
         "~p: Project modules (~p) with all source files:~n  ~p~n",

--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -246,14 +246,14 @@ module_files_to_parse(Files, BuildDir) ->
             %% All files are from dependencies.
             %% In case of multiple files are found for a module and all of them
             %% are in the build directory (_build) then most probably those are
-            %% the same but located under different rebar3 relase targets.
+            %% the same but located under different rebar3 release targets.
             %% Which one to choose? :S
             %% Choose the first, if all are the same. (But are they?)
             [hd(lists:sort(Files))]; % sort just to choose the 1st consistently
         {_, NonBuildFiles} ->
             %% Files are under both '_build' and repo. The files under
             %% '_build' are sym-linked by rebar3, ignore these.
-            %% Parse the orignal ones only.
+            %% Parse the original ones only.
             NonBuildFiles
     end.
 
@@ -263,7 +263,7 @@ scan_project_files(State = #state{project_modules = OldProjectModules}) ->
     BuildDir = get_build_dir(), % relative to workspace root or 'undefined'
     SearchExcludeConf = gen_lsp_config_server:search_files_exclude(),
     SearchExclude = lsp_utils:search_exclude_globs_to_regexps(SearchExcludeConf),
-    %% Find all source (*.erl) files not exluded by any filter
+    %% Find all source (*.erl) files not excluded by any filter
     CollectProjSrcFilesFun =
         fun(File, AccProjectModules = #{}) ->
             case lsp_utils:is_path_excluded(File, SearchExclude) of

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -55,13 +55,13 @@ cancelRequest(_Socket, _Params) ->
 setTrace(_Socket, _Params) ->
     ok.
 
-configuration(Socket, [ErlangSection, FilesSection, ComputedSecton, HttpSection, SearchSection]) ->
+configuration(Socket, [ErlangSection, FilesSection, ComputedSection, HttpSection, SearchSection]) ->
     Documents = gen_lsp_doc_server:opened_documents(),
     gen_lsp_config_server:update_config(erlang, ErlangSection),
     %% because 'verbose' is stored in erlang section, loggin should be after update erlang config
     gen_lsp_server:lsp_log("configuration ~p", [Documents]),
     gen_lsp_config_server:update_config(files, FilesSection),
-    gen_lsp_config_server:update_config(computed, ComputedSecton),
+    gen_lsp_config_server:update_config(computed, ComputedSection),
     gen_lsp_config_server:update_config(http, HttpSection),
     gen_lsp_config_server:update_config(search, SearchSection),
     gen_lsp_server:lsp_log("vscode configuration:~n"
@@ -70,7 +70,7 @@ configuration(Socket, [ErlangSection, FilesSection, ComputedSecton, HttpSection,
                            " - computed: ~p~n"
                            " - http: ~p~n"
                            " - search: ~p",
-                           [ErlangSection, FilesSection, ComputedSecton,
+                           [ErlangSection, FilesSection, ComputedSection,
                             HttpSection, SearchSection]),
 
     %% Scan workspace for source files


### PR DESCRIPTION
I've noticed the extension search for and try to parse source files with `.erl` ending, but as this pattern is regular expression, the dot can be any character, not necessarily a literal dot. For example `run_erl`, `to_erl`  or `start_erl` scripts of Erlang/OTP. Let's require literal dot as proper file extension.

Additionally fix some typos around this function.