### PR TITLE
Add option to compress large ETS lookup tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Support for Erlang tools, including rebar3, EUnit and Dialyzer
 - `erlang.includePaths` - Include paths are read from rebar.config, and also standard set of paths is used. This setting is for special cases when the default behaviour is not enough
 - `erlang.linting` - Enable/disable dynamic validation of opened Erlang source files
 - `erlang.codeLensEnabled` - Enable/Disable CodeLens
+- `erlang.compressLargeEtsTables` - Enable/disable compression of large ETS lookup tables (mainly used for code navigation) to consume less memory. Please note, it might impact performance.
 - `erlang.inlayHintsEnabled` - Enable/Disable InlayHints
 - `erlang.verbose` - Activate technical traces for use in the extension development
 

--- a/lib/ErlangConfigurationProvider.ts
+++ b/lib/ErlangConfigurationProvider.ts
@@ -31,6 +31,7 @@ export function configurationChanged(): void {
         erlangDistributedNode: erlangConf.get("erlangDistributedNode", false),
         rebarPath: resolveVariables(erlangConf.get<string>("rebarPath", null)),
         codeLensEnabled: erlangConf.get<boolean>('codeLensEnabled', false),
+        compressLargeEtsTables: erlangConf.get("compressLargeEtsTables", false),
         inlayHintsEnabled: erlangConf.get<boolean>('inlayHintsEnabled', false),
         debuggerRunMode: erlangConf.get<string>("debuggerRunMode", "Server"),
         includePaths: erlangConf.get("includePaths", []),

--- a/lib/GenericShell.ts
+++ b/lib/GenericShell.ts
@@ -39,6 +39,7 @@ export class GenericShell extends EventEmitter {
     public erlangPath: string = null;
 	public erlangArgs : string[] = [];
 	public erlangDistributedNode: boolean = false;
+	public compressLargeEtsTables: boolean = false;
 
     //provide IGenericShellConfiguration, in order to avoid dependencies on vscode module (it doesn't works with debugger-adpater)
     constructor(logOutput?: ILogOutput, shellOutput?: IShellOutput, erlangConfiguration?: ErlangSettings) {
@@ -67,6 +68,7 @@ export class GenericShell extends EventEmitter {
             }
             this.erlangArgs = erlangConfiguration.erlangArgs;
             this.erlangDistributedNode = erlangConfiguration.erlangDistributedNode;
+            this.compressLargeEtsTables = erlangConfiguration.compressLargeEtsTables;
         }
     }
 

--- a/lib/erlangSettings.ts
+++ b/lib/erlangSettings.ts
@@ -7,6 +7,7 @@ export interface ErlangSettings {
 	includePaths : string[];
 	linting: boolean;
 	codeLensEnabled : boolean;
+	compressLargeEtsTables: boolean;
 	inlayHintsEnabled: boolean;
 	verbose: boolean;
 	debuggerRunMode : string;

--- a/lib/lsp/ErlangShellLSP.ts
+++ b/lib/lsp/ErlangShellLSP.ts
@@ -13,6 +13,11 @@ export class ErlangShellLSP extends GenericShell {
                 "-sname", "vscode_" + listen_port.toString(),
                 "-setcookie", "vscode_" + listen_port.toString());
         }
+        // Turn on compression of large ETS lookup tables to consume less memory
+        if (this.compressLargeEtsTables) {
+            debugStartArgs.push(
+                "-vscode_ets_compressed", "true");
+        }
         // Use special command line arguments
         if (this.erlangArgs) {
             debugStartArgs = debugStartArgs.concat(this.erlangArgs)

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 				},
 				"erlang.erlangDistributedNode": {
 					"type": "boolean",
-					"description": "Start the Erlang backend in a distributed Erlang node. Could be usefull for extension development. Note, it starts EPMD if not running yet.",
+					"description": "Start the Erlang backend in a distributed Erlang node. Could be useful for extension development. Note, it starts EPMD if not running yet.",
 					"default": false
 				},
 				"erlang.rebarPath": {
@@ -220,6 +220,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enable/disable references CodeLens on functions."
+				},
+				"erlang.compressLargeEtsTables": {
+					"type": "boolean",
+					"description": "Enable/disable compression of large ETS lookup tables (mainly used for code navigation) to consume less memory. Please note, it might impact performance.",
+					"default": false
 				},
 				"erlang.inlayHintsEnabled": {
 					"type": "boolean",


### PR DESCRIPTION
Add a configuration setting to compress large ETS lookup tables (mainly used for code navigation) to consume less memory. Please note, it will make table operations slower, therefore it might impact performance of code navigation.

Rational:
In shared environment where many instances of `vscode_erlang` run in the same time on large code bases, noticeable amount of memory can be consumed by this extension. In this case turning on the newly created option `compressLargeEtsTables` might ease the situation.