### PR TITLE
Add option for cache management

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Support for Erlang tools, including rebar3, EUnit and Dialyzer
 - `erlang.includePaths` - Include paths are read from rebar.config, and also standard set of paths is used. This setting is for special cases when the default behaviour is not enough
 - `erlang.linting` - Enable/disable dynamic validation of opened Erlang source files
 - `erlang.codeLensEnabled` - Enable/Disable CodeLens
+- `erlang.cacheManagement` - Specify where and how to store large cache tables
 - `erlang.inlayHintsEnabled` - Enable/Disable InlayHints
 - `erlang.verbose` - Activate technical traces for use in the extension development
 

--- a/apps/erlangbridge/src/gen_lsp_config_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_config_server.erl
@@ -1,13 +1,15 @@
 -module(gen_lsp_config_server).
-
 -behavior(gen_server).
--export([start_link/0]).
 
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+%% API
+-export([start_link/0]).
 -export([standard_modules/0, bifs/0]).
 -export([update_config/2, root/0, tmpdir/0, codeLensEnabled/0, includePaths/0, linting/0,
-        verbose/0, autosave/0, proxy/0, search_files_exclude/0, search_exclude/0,
-        formatting_line_length/0, inlayHintsEnabled/0, verbose_is_include/1]).
+         verbose/0, autosave/0, proxy/0, search_files_exclude/0, search_exclude/0,
+         formatting_line_length/0, inlayHintsEnabled/0, verbose_is_include/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -include("lsp_log.hrl").
 -define(SERVER, ?MODULE).

--- a/apps/erlangbridge/src/gen_lsp_config_sup.erl
+++ b/apps/erlangbridge/src/gen_lsp_config_sup.erl
@@ -1,6 +1,11 @@
 -module(gen_lsp_config_sup).
+-behaviour(supervisor).
 
--export([init/1, start_link/0]).
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/apps/erlangbridge/src/gen_lsp_doc_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_server.erl
@@ -1,13 +1,17 @@
 -module(gen_lsp_doc_server).
-
 -behavior(gen_server).
+
+%% API
 -export([start_link/0]).
 
 -export([document_opened/2, document_changed/2, document_closed/1, opened_documents/0, get_document_contents/1, parse_document/1]).
 -export([project_file_added/1, project_file_changed/1, project_file_deleted/1]).
 -export([get_syntax_tree/1, get_dodged_syntax_tree/1, get_references/1, get_inlayhints/1]).
 -export([root_available/0, config_change/0, project_modules/0, get_module_file/1, get_module_files/1, get_build_dir/0, find_source_file/1]).
+
+%% gen_server callbacks
 -export([init/1,handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
 -include("./lsp_log.hrl").
 
 -define(SERVER, ?MODULE).

--- a/apps/erlangbridge/src/gen_lsp_doc_sup.erl
+++ b/apps/erlangbridge/src/gen_lsp_doc_sup.erl
@@ -1,6 +1,11 @@
 -module(gen_lsp_doc_sup).
+-behaviour(supervisor).
 
--export([init/1, start_link/0]).
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/apps/erlangbridge/src/gen_lsp_help_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_help_server.erl
@@ -1,10 +1,12 @@
 -module(gen_lsp_help_server).
-
 -behavior(gen_server).
--export([start_link/0]).
 
--export([init/1,handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+%% API
+-export([start_link/0]).
 -export([get_help/2,get_help/5, render_help_body/3]).
+
+%% gen_server callbacks
+-export([init/1,handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
 

--- a/apps/erlangbridge/src/gen_lsp_help_sup.erl
+++ b/apps/erlangbridge/src/gen_lsp_help_sup.erl
@@ -1,6 +1,11 @@
 -module(gen_lsp_help_sup).
+-behaviour(supervisor).
 
--export([init/1, start_link/0]).
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/apps/erlangbridge/src/gen_lsp_server.erl
+++ b/apps/erlangbridge/src/gen_lsp_server.erl
@@ -1,5 +1,4 @@
 -module(gen_lsp_server).
-
 -behavior(gen_server).
 
 %inspired from https://github.com/kevinlynx/erlang-tcpserver/blob/master/test/test.erl
@@ -9,12 +8,12 @@
 % http://learnyousomeerlang.com/buckets-of-sockets
 
 
-%API
+%% API
 -export([start_link/1, start_link/2]).
-
-%export for gen_server
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 -export([lsp_log/2, send_to_client/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
 %state

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -73,7 +73,7 @@ configuration(Socket, [ErlangSection, FilesSection, ComputedSection, HttpSection
     Documents = gen_lsp_doc_server:opened_documents(),
     gen_lsp_config_server:update_config(erlang, ErlangSection),
     %% because 'verbose' is stored in erlang section, loggin should be after update erlang config
-    gen_lsp_server:lsp_log("configuration ~p", [Documents]),
+    gen_lsp_server:lsp_log("Opened documents ~p", [Documents]),
     gen_lsp_config_server:update_config(files, FilesSection),
     gen_lsp_config_server:update_config(computed, ComputedSection),
     gen_lsp_config_server:update_config(http, HttpSection),

--- a/apps/erlangbridge/src/lsp_handlers.erl
+++ b/apps/erlangbridge/src/lsp_handlers.erl
@@ -87,6 +87,14 @@ configuration(Socket, [ErlangSection, FilesSection, ComputedSection, HttpSection
                            [ErlangSection, FilesSection, ComputedSection,
                             HttpSection, SearchSection]),
 
+    %% Delete old caches left there by brutally killed extension instances
+    case ComputedSection of
+        #{tmpdir := TmpDir, username := UserName} ->
+            gen_lsp_doc_server:delete_unused_caches(TmpDir, UserName);
+        _ ->
+            ok
+    end,
+
     %% Scan workspace for source files
     gen_lsp_doc_server:config_change(),
 

--- a/apps/erlangbridge/src/lsp_utils.erl
+++ b/apps/erlangbridge/src/lsp_utils.erl
@@ -311,17 +311,17 @@ make_temporary_file(Contents) ->
     file:write_file(TempFile, Contents),
     TempFile.
 
-index_of(Fun, List) -> 
-    case lists:foldl(fun 
-        (X, {not_found, I}) -> 
+index_of(Fun, List) ->
+    FoldFun =
+        fun(X, {not_found, I}) ->
             case Fun(X) of
                 true -> {ok, I+1};
-                _ -> {not_found, I+1}
+                _    -> {not_found, I+1}
             end;
-        (_, Acc) -> Acc 
-        end,{not_found, -1}, List) 
-    of
+        (_, Acc) ->
+            Acc
+        end,
+    case lists:foldl(FoldFun, {not_found, -1}, List) of
         {not_found, _} -> -1;
         {ok, Index} -> Index
     end.
-        

--- a/apps/erlangbridge/src/vscode_lsp_app.erl
+++ b/apps/erlangbridge/src/vscode_lsp_app.erl
@@ -52,6 +52,7 @@ start(_Type, _Args) ->
     application:start(inets),
     %uncomment to monitor erlang processes
     %spawn(fun() -> observer:start() end),
+    gen_lsp_doc_server:persist_cache_mgmt_opts(),
     Port = get_port(),
     case vscode_lsp_app_sup:start_link(Port) of
         {ok, Pid} -> {ok, Pid};

--- a/apps/erlangbridge/src/vscode_lsp_app.erl
+++ b/apps/erlangbridge/src/vscode_lsp_app.erl
@@ -1,16 +1,52 @@
+%%%-------------------------------------------------------------------
+%%% @doc Erlang Language Server Process (LSP) for Visual Studio Code.
+%%%
+%%% Application supervision tree:
+%%%
+%%% ```
+%%% vscode_lsp_entry
+%%%  |
+%%%  | vscode_lsp [app.src]
+%%%  |
+%%% vscode_lsp_app [app]
+%%%  |
+%%% vscode_lsp_app_sup [sup]
+%%%  |
+%%%  +--gen_lsp_sup [sup]
+%%%  |   |
+%%%  |   +--gen_lsp_server [gen_server]
+%%%  |
+%%%  +--gen_lsp_doc_sup [sup]
+%%%  |   |  - (D)ETS document_contents
+%%%  |   |  - (D)ETS document_inlayhints
+%%%  |   |  - (D)ETS dodged_syntax_tree
+%%%  |   |  - ETS references
+%%%  |   |  - (D)ETS syntax_tree
+%%%  |   |
+%%%  |   +--gen_lsp_doc_server [gen_server]
+%%%  |
+%%%  +--gen_lsp_config_sup [sup]
+%%%  |   |
+%%%  |   +--gen_lsp_config_server [gen_server]
+%%%  |
+%%%  +--gen_lsp_help_sup [sup]
+%%%      |
+%%%      +--gen_lsp_help_server [gen_server]
+%%% '''
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
 -module(vscode_lsp_app).
-
 -behavior(application).
 
+%% Application callbacks
 -export([start/2, stop/1]).
-
 
 get_port() ->
     case init:get_argument(vscode_port) of
-    {ok, [[P]]} -> P;
-    _ -> "0"
+        {ok, [[P]]} -> P;
+        _ -> "0"
     end.
-    
 
 start(_Type, _Args) ->
     application:start(inets),
@@ -18,9 +54,8 @@ start(_Type, _Args) ->
     %spawn(fun() -> observer:start() end),
     Port = get_port(),
     case vscode_lsp_app_sup:start_link(Port) of
-    {ok, Pid} ->
-        {ok, Pid};
-    _Any -> _Any        
+        {ok, Pid} -> {ok, Pid};
+        _Any      -> _Any
     end.
 
 stop(_State) ->

--- a/apps/erlangbridge/src/vscode_lsp_app_sup.erl
+++ b/apps/erlangbridge/src/vscode_lsp_app_sup.erl
@@ -1,6 +1,11 @@
 -module(vscode_lsp_app_sup).
+-behaviour(supervisor).
 
--export([init/1, start_link/1, start_sup_socket/1, start_sup_doc/0, start_sup_config/0, start_sup_help/0, start_child/1]).
+%% API
+-export([start_link/1, start_sup_socket/1, start_sup_doc/0, start_sup_config/0, start_sup_help/0, start_child/1]).
+
+%% Supervisor callbacks
+-export([init/1]).
 
 start_link(VsCodePort) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, VsCodePort).
@@ -20,17 +25,12 @@ socket_spec(VsCodePort) ->
     modules => [gen_lsp_sup],
     type => supervisor}.
 
-start_sup_socket(VsCodePort) ->
-    supervisor:start_child({local, ?MODULE}, socket_spec(VsCodePort)).
-
 doc_spec() ->
     #{id => gen_lsp_doc_sup,
     start => {gen_lsp_doc_sup, start_link, []},
     restart => permanent,
     modules => [gen_lsp_doc_sup],
     type => supervisor}.
-%        {gen_lsp_doc_sup, {gen_lsp_doc_sup, start_link, []},
-%                        permanent, infinity, supervisor, [gen_lsp_doc_sup]}.
 
 config_spec() ->
     #{id => gen_lsp_config_sup,
@@ -45,6 +45,9 @@ help_spec() ->
     restart => permanent,
     modules => [gen_lsp_help_sup],
     type => supervisor}.
+
+start_sup_socket(VsCodePort) ->
+    supervisor:start_child({local, ?MODULE}, socket_spec(VsCodePort)).
 
 start_sup_doc() ->
     supervisor:start_child(?MODULE, doc_spec()).

--- a/lib/ErlangConfigurationProvider.ts
+++ b/lib/ErlangConfigurationProvider.ts
@@ -31,6 +31,7 @@ export function configurationChanged(): void {
         erlangDistributedNode: erlangConf.get("erlangDistributedNode", false),
         rebarPath: resolveVariables(erlangConf.get<string>("rebarPath", null)),
         codeLensEnabled: erlangConf.get<boolean>('codeLensEnabled', false),
+        cacheManagement: erlangConf.get("cacheManagement", "memory"),
         inlayHintsEnabled: erlangConf.get<boolean>('inlayHintsEnabled', false),
         debuggerRunMode: erlangConf.get<string>("debuggerRunMode", "Server"),
         includePaths: erlangConf.get("includePaths", []),

--- a/lib/GenericShell.ts
+++ b/lib/GenericShell.ts
@@ -39,6 +39,7 @@ export class GenericShell extends EventEmitter {
     public erlangPath: string = null;
 	public erlangArgs : string[] = [];
 	public erlangDistributedNode: boolean = false;
+    public cacheManagement: string = "memory";
 
     //provide IGenericShellConfiguration, in order to avoid dependencies on vscode module (it doesn't works with debugger-adpater)
     constructor(logOutput?: ILogOutput, shellOutput?: IShellOutput, erlangConfiguration?: ErlangSettings) {
@@ -67,6 +68,7 @@ export class GenericShell extends EventEmitter {
             }
             this.erlangArgs = erlangConfiguration.erlangArgs;
             this.erlangDistributedNode = erlangConfiguration.erlangDistributedNode;
+            this.cacheManagement = erlangConfiguration.cacheManagement;
         }
     }
 

--- a/lib/erlangSettings.ts
+++ b/lib/erlangSettings.ts
@@ -7,6 +7,7 @@ export interface ErlangSettings {
 	includePaths : string[];
 	linting: boolean;
 	codeLensEnabled : boolean;
+	cacheManagement: string;
 	inlayHintsEnabled: boolean;
 	verbose: boolean;
 	debuggerRunMode : string;

--- a/lib/lsp/ErlangShellLSP.ts
+++ b/lib/lsp/ErlangShellLSP.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import { GenericShell, ILogOutput } from '../GenericShell';
 import { getElangConfigConfiguration } from '../ErlangConfigurationProvider';
 
@@ -12,6 +13,21 @@ export class ErlangShellLSP extends GenericShell {
             debugStartArgs.push(
                 "-sname", "vscode_" + listen_port.toString(),
                 "-setcookie", "vscode_" + listen_port.toString());
+        }
+        // Set management mode for large caches
+        switch (this.cacheManagement) {
+            case 'file':
+                debugStartArgs.push("-vscode_cache_mgmt", "file", os.userInfo().username, os.tmpdir());
+                break;
+
+            case 'compressed memory':
+                debugStartArgs.push("-vscode_cache_mgmt", "memory", "compressed");
+                break;
+
+            case 'memory':
+            default:
+                debugStartArgs.push("-vscode_cache_mgmt", "memory");
+                break;
         }
         // Use special command line arguments
         if (this.erlangArgs) {

--- a/lib/lsp/lspclientextension.ts
+++ b/lib/lsp/lspclientextension.ts
@@ -75,7 +75,8 @@ namespace Configuration {
 				if (item.section === "<computed>") {
 					result.push({
 						autosave: Workspace.getConfiguration("files").get("autoSave", "afterDelay") === "afterDelay",
-						tmpdir: os.tmpdir()
+						tmpdir: os.tmpdir(),
+						username: os.userInfo().username
 					});
 				} else if (item.section === "erlang") {
 					result.push(resolveErlangSettings(Workspace.getConfiguration(item.section)))

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 				},
 				"erlang.erlangDistributedNode": {
 					"type": "boolean",
-					"description": "Start the Erlang backend in a distributed Erlang node. Could be usefull for extension development. Note, it starts EPMD if not running yet.",
+					"description": "Start the Erlang backend in a distributed Erlang node. Could be useful for extension development. Note, it starts EPMD if not running yet.",
 					"default": false
 				},
 				"erlang.rebarPath": {
@@ -215,6 +215,21 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enable/disable dynamic validation of opened Erlang source files."
+				},
+				"erlang.cacheManagement": {
+					"type": "string",
+					"default": "memory",
+					"description": "Specify where and how to store large cache tables.",
+					"enum": [
+						"memory",
+						"compressed memory",
+						"file"
+					],
+					"enumDescriptions": [
+						"Store in memory",
+						"Store in memory and apply lightweight compression to consume less memory (approx. 50%)",
+						"Store in temporary files"
+					]
 				},
 				"erlang.codeLensEnabled": {
 					"type": "boolean",


### PR DESCRIPTION
Add a configuration setting to change the storage mode for large cache tables (mainly used for code navigation). Available modes:

- `memory` (default, original): use ETS tables
- `compressed memory`: use ETS tables with `compressed` flag turned on.
- `file`: use DETS tables saved into temporary files.

Why is this configuration option needed?

In shared environment, where many instances of `vscode_erlang` run in the same time on large code bases, noticeable amount of memory can be consumed by this extension that eventually can exhaust all the memory.

Notes for `compressed memory`:

Some simple tests, done in the above explained scenario, showed memory consumption dropped by 50% when `compressed memory` is configured.

Notes for `file`:

As multiple extension instances can run in the same time on the same host, even in the same workspace, we cannot use static filenames, nor workspace specific filenames to create DETS tables. The only option is to use unique filenames, like temporary files. Of course, it has a drawback, temporary files must be deleted on exit otherwise those will consume a lot of disk space after a while. If the extension is shut down normally, it's not a problem, the extension deletes it's own cache.

However, if some extension is terminated brutally, the cache files left on the disk. Hence, an automatic mechanism is hooked to the points when configuration is received from Visual Studio Code, and to normal shutdown, to look for cache directories created by yet not running extension, and delete them.

Reusing old cache files is theoretically possible if only one extension instance run in a workspace, VSCode is closed and reopened, then the new extension instance could continue where the previous one stopped. But, as multiple extension instances can run in the same workspace, it can easily go wrong. Therefore it is simpler to use instance specific DETS files, just like instance specific ETS tables.