### PR TITLE
Bind LSP and debugger sockets to 127.0.0.1

### DIFF
--- a/apps/erlangbridge/src/gen_connection.erl
+++ b/apps/erlangbridge/src/gen_connection.erl
@@ -41,7 +41,7 @@ send_message_to_vscode(Port, Verb, Data) ->
 %-------------------------------
 % Command receiver (from nodejs)
 %-------------------------------
--define(TCP_OPTIONS, [binary, {active, false}]).
+-define(TCP_OPTIONS, [binary, {active, false}, {ip, {127,0,0,1}}]).
 
 start_command_server(VsCodePort, Module) ->
     spawn(fun () ->

--- a/apps/erlangbridge/src/gen_lsp_sup.erl
+++ b/apps/erlangbridge/src/gen_lsp_sup.erl
@@ -7,7 +7,7 @@
 %% Supervisor callbacks
 -export([init/1]).
 
--define(TCP_OPTIONS, [binary, {packet, raw}, {active, once}, {reuseaddr, true}]).
+-define(TCP_OPTIONS, [binary, {packet, raw}, {active, once}, {reuseaddr, true}, {ip, {127,0,0,1}}]).
 
 start_link(Port) ->
     case supervisor:start_link({local, ?MODULE}, ?MODULE, Port) of

--- a/apps/erlangbridge/test/gen_connection_SUITE.erl
+++ b/apps/erlangbridge/test/gen_connection_SUITE.erl
@@ -1,0 +1,55 @@
+-module(gen_connection_SUITE).
+-behaviour(gen_connection).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-include("./testlog.hrl").
+
+all() -> [command_server_binds_to_loopback].
+
+%% gen_connection callbacks: this suite is the callback module.
+%% get_port/0 returns a free loopback port nobody listens on, so the
+%% "listen" notification POST fails and gen_connection ignores the result.
+get_port() -> free_port().
+init(_Port) -> ok.
+decode_request(_Data) -> #{}.
+
+command_server_binds_to_loopback(_Config) ->
+    Before = erlang:ports(),
+    ok = gen_connection:start(?MODULE),
+    LSock = wait_for_listener(Before, 50),
+    %% gen_connection spawns the command server unlinked and exposes no
+    %% stop API. Kill the socket owner to close the listen socket: closing
+    %% it from here would crash the accept loop with a badmatch instead.
+    {connected, Owner} = erlang:port_info(LSock, connected),
+    try
+        {ok, {Addr, Port}} = inet:sockname(LSock),
+        ?assertEqual({127,0,0,1}, Addr),
+        {ok, C} = gen_tcp:connect({127,0,0,1}, Port, [], 1000),
+        ok = gen_tcp:close(C)
+    after
+        exit(Owner, kill)
+    end.
+
+free_port() ->
+    {ok, S} = gen_tcp:listen(0, [{ip, {127,0,0,1}}]),
+    {ok, P} = inet:port(S),
+    ok = gen_tcp:close(S),
+    P.
+
+%% Discovery via erlang:ports/0 assumes the default inet backend
+%% (gen_tcp sockets are ports). A listen socket has no peer; an
+%% accepted or client socket does.
+wait_for_listener(_Before, 0) ->
+    ct:fail(command_server_not_listening);
+wait_for_listener(Before, N) ->
+    New = [P || P <- erlang:ports() -- Before,
+                erlang:port_info(P, name) =:= {name, "tcp_inet"},
+                inet:peername(P) =:= {error, enotconn}],
+    case New of
+        [One] -> One;
+        _ -> timer:sleep(100), wait_for_listener(Before, N - 1)
+    end.

--- a/apps/erlangbridge/test/gen_lsp_sup_SUITE.erl
+++ b/apps/erlangbridge/test/gen_lsp_sup_SUITE.erl
@@ -1,0 +1,29 @@
+-module(gen_lsp_sup_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-include("./testlog.hrl").
+
+all() -> [lsp_listener_binds_to_loopback].
+
+init_per_suite(Config) ->
+    StartResult = application:start(vscode_lsp, permanent),
+    ?assertEqual(ok, StartResult),
+    ErlangSection = #{verbose => false},
+    gen_lsp_config_server:update_config(erlang, ErlangSection),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(vscode_lsp),
+    ok.
+
+%% gen_lsp_sup:init/1 opens the listen socket and hands it to its
+%% gen_lsp_server child through the child spec start arguments.
+lsp_listener_binds_to_loopback(_Config) ->
+    [{_, Child, _, _}] = supervisor:which_children(gen_lsp_sup),
+    {ok, #{start := {gen_lsp_server, start_link, [_Port, LSock]}}} =
+        supervisor:get_childspec(gen_lsp_sup, Child),
+    ?assertMatch({ok, {{127,0,0,1}, _}}, inet:sockname(LSock)).

--- a/lib/ErlangAdapterDescriptorFactory.ts
+++ b/lib/ErlangAdapterDescriptorFactory.ts
@@ -15,7 +15,7 @@ export class ErlangDebugAdapterDescriptorFactory implements DebugAdapterDescript
 				const session = new ErlangDebugSession(true);
 				session.setRunAsServer(true);
 				session.start(<NodeJS.ReadableStream>socket, socket);
-			}).listen(0);
+			}).listen(0, '127.0.0.1');
 		}
 
 		// make VS Code connect to debug server

--- a/lib/lsp/lspclientextension.ts
+++ b/lib/lsp/lspclientextension.ts
@@ -147,7 +147,7 @@ function waitForSocket(options: any, callback: any, _tries: any) {
 		throw new Error('.port is a required option');
 
 	var maxTries = options.tries || MAX_TRIES;
-	var host = options.host || 'localhost';
+	var host = options.host || '127.0.0.1';
 	var port = options.port;
 
 
@@ -193,7 +193,7 @@ function getPort(callback) {
 	var server = Net.createServer(function (sock) {
 		sock.end('OK\n');
 	});
-	server.listen(0, function () {
+	server.listen(0, '127.0.0.1', function () {
 		var port = (<Net.AddressInfo>server.address()).port;
 		server.close(function () {
 			callback(port);


### PR DESCRIPTION
Fixes #328

## Change

Bind every listening socket opened by the extension's own code to loopback instead of all interfaces:

- `apps/erlangbridge/src/gen_lsp_sup.erl`: `{ip, {127,0,0,1}}` in `TCP_OPTIONS` (LSP listener)
- `apps/erlangbridge/src/gen_connection.erl`: `{ip, {127,0,0,1}}` in `TCP_OPTIONS` (debugger command server)
- `lib/ErlangAdapterDescriptorFactory.ts`: `listen(0, '127.0.0.1')` (debug adapter server, `erlang.debuggerRunMode: "server"`)
- `lib/lsp/lspclientextension.ts`: `listen(0, '127.0.0.1')` in `getPort()` (free-port probe); the LSP client in `waitForSocket()` now connects to `127.0.0.1` instead of resolving `localhost`

The first two are the sockets described in #328; the other two listeners were found while preparing this PR (see my comment on #328). The client-side change opens no listening socket; it only removes the `localhost` lookup between the client and a server that is now explicitly bound to `127.0.0.1`.

No supported configuration is affected: every client of these sockets already connects over loopback (`lib/lsp/lspclientextension.ts`, `lib/erlangConnection.ts`, and VS Code itself for a `DebugAdapterServer` with no host given), the Erlang listeners were already IPv4-only, and the extension host always runs on the same machine as the Erlang processes (also with VS Code Remote and Dev Containers).

## How to verify

**Automated — one command, red on `master`, green here:**

```
./rebar3 ct
```

Two new suites, `apps/erlangbridge/test/gen_lsp_sup_SUITE.erl` and `apps/erlangbridge/test/gen_connection_SUITE.erl`, assert that `inet:sockname/1` on each listen socket returns `{127,0,0,1}`; `gen_connection_SUITE` also checks that a loopback client still connects. On `master` both fail with `{0,0,0,0}`; on this branch all 5 tests pass (OTP 25 and 27). `xvfb-run -a npm test` also passes — the diagnostics test talks to the real LSP server over its socket.

**Manual — measured with the extension's own `erl` command lines, started by hand in a Linux container (LSP on port 9000, debugger command server on its ephemeral port), then `ss -ltnp | grep beam` inside and `nc -zv` from the container's LAN address (172.17.0.2) and from loopback:**

before (master):
```
LISTEN 0 5 0.0.0.0:9000    0.0.0.0:* users:(("beam.smp",pid=7,fd=17))
LISTEN 0 5 0.0.0.0:53459   0.0.0.0:* users:(("beam.smp",pid=83,fd=17))
Connection to 172.17.0.2 9000 port [tcp/*] succeeded!
Connection to 172.17.0.2 53459 port [tcp/*] succeeded!
```

after (this branch):
```
LISTEN 0 5 127.0.0.1:9000  0.0.0.0:* users:(("beam.smp",pid=7,fd=17))
LISTEN 0 5 127.0.0.1:35661 0.0.0.0:* users:(("beam.smp",pid=77,fd=17))
nc: connect to 172.17.0.2 port 9000 (tcp) failed: Connection refused
nc: connect to 172.17.0.2 port 35661 (tcp) failed: Connection refused
Connection to 127.0.0.1 9000 port [tcp/*] succeeded!
Connection to 127.0.0.1 35661 port [tcp/*] succeeded!
```

To reproduce in VS Code: launch the extension (F5), open an `.erl` file, start a debug session, and run `ss -ltnp | grep beam` (macOS: `lsof -nP -iTCP -sTCP:LISTEN | grep beam`) on `master` and on this branch.

## Not in this PR

- Loopback binding is not authentication: the debugger command channel (`vscode_connection.erl`, `debugger_eval`) and the LSP request handlers (`lsp_handlers.erl`, client-named file paths) remain reachable by processes on the same host.
- Item 3 of #328 (`erlang.erlangDistributedNode`: distribution listener, port-derived cookie, epmd) is an opt-in feature with its own trade-offs and is left for a separate issue.

Suggested `CHANGELOG.md` line, if useful:
`* [328](https://github.com/pgourlain/vscode_erlang/issues/328) : Bind LSP and debugger sockets to 127.0.0.1`
