### PR TITLE
Bind Erlang distribution and epmd to loopback when erlangDistributedNode is enabled

### DIFF
--- a/lib/lsp/ErlangShellLSP.ts
+++ b/lib/lsp/ErlangShellLSP.ts
@@ -8,11 +8,20 @@ export class ErlangShellLSP extends GenericShell {
     }
     public Start(erlPath:string, startDir: string, listen_port: number, bridgePath: string, args: string): Promise<boolean> {
         var debugStartArgs = [];
-        // Start as distributed node to be able to connect to the Erlang VM for investigation
+        // Start as distributed node to be able to connect to the Erlang VM for investigation.
+        // Bind distribution to loopback: a network-reachable distribution port plus the
+        // predictable cookie below is the classic Erlang RCE (rpc:call/4 os:cmd/1). Use
+        // -name <node>@127.0.0.1 so local remsh still connects over loopback (a short name
+        // resolves to the LAN address, which the loopback-bound listener refuses), and
+        // confine both the distribution listener (inet_dist_use_interface) and epmd
+        // (ERL_EPMD_ADDRESS) to 127.0.0.1. The {127,0,0,1} tuple is double-quoted so the
+        // shell (GenericShell spawns with shell:true) passes it as a single argument.
         if (this.erlangDistributedNode) {
             debugStartArgs.push(
-                "-sname", "vscode_" + listen_port.toString(),
-                "-setcookie", "vscode_" + listen_port.toString());
+                "-name", "vscode_" + listen_port.toString() + "@127.0.0.1",
+                "-setcookie", "vscode_" + listen_port.toString(),
+                "-kernel", "inet_dist_use_interface", '"{127,0,0,1}"',
+                "-env", "ERL_EPMD_ADDRESS", "127.0.0.1");
         }
         // Set management mode for large caches
         switch (this.cacheManagement) {

--- a/test/test-suite/erlangShellLSP.test.ts
+++ b/test/test-suite/erlangShellLSP.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert';
+import { ErlangShellLSP } from '../../lib/lsp/ErlangShellLSP';
+
+// Capture the argument list ErlangShellLSP.Start would pass to `erl`, without
+// actually spawning a process, by overriding the protected LaunchProcess.
+function captureStartArgs(distributed: boolean): Promise<string[]> {
+    const log = { appendLine: (_: string) => {}, debug: (_: string) => {} };
+    const shell = new ErlangShellLSP(log);
+    shell.erlangDistributedNode = distributed;
+    let captured: string[] = [];
+    (shell as any).LaunchProcess = (_name: string, _dir: string, args: string[]) => {
+        captured = args;
+        return Promise.resolve(true);
+    };
+    return shell.Start('', '.', 12345, 'src', '').then(() => captured);
+}
+
+suite('ErlangShellLSP distribution hardening', () => {
+    test('distributed node binds distribution and epmd to loopback', async () => {
+        const args = await captureStartArgs(true);
+        // -name <node>@127.0.0.1 (not -sname) so local remsh still reaches the
+        // loopback-bound listener.
+        assert.ok(args.includes('-name'), '-name flag present');
+        assert.ok(args.includes('vscode_12345@127.0.0.1'), 'node named on loopback host');
+        assert.ok(!args.includes('-sname'), '-sname must not be used (resolves to LAN host)');
+        // Distribution listener and epmd confined to loopback.
+        assert.ok(args.includes('inet_dist_use_interface'), 'inet_dist_use_interface present');
+        assert.ok(args.includes('"{127,0,0,1}"'), 'loopback tuple quoted for the shell');
+        assert.ok(args.includes('ERL_EPMD_ADDRESS'), 'ERL_EPMD_ADDRESS present');
+        assert.ok(args.includes('127.0.0.1'), 'epmd bound to loopback');
+    });
+
+    test('non-distributed node adds no distribution flags', async () => {
+        const args = await captureStartArgs(false);
+        assert.ok(!args.includes('-name'), 'no -name when not distributed');
+        assert.ok(!args.includes('-sname'), 'no -sname when not distributed');
+        assert.ok(!args.includes('inet_dist_use_interface'), 'no distribution binding when not distributed');
+        assert.ok(!args.includes('ERL_EPMD_ADDRESS'), 'no epmd binding when not distributed');
+    });
+});


### PR DESCRIPTION
Follows up #328 (the distribution/epmd hardening noted there; the loopback binding of the LSP and debugger sockets is handled separately in #329).

## Change

When `erlang.erlangDistributedNode` is enabled, the LSP node is started with
`-sname vscode_<port> -setcookie vscode_<port>` (`lib/lsp/ErlangShellLSP.ts`).
By OTP default the distribution listener and epmd (TCP 4369) bind all
interfaces, so a node started for local investigation is reachable from the
network; combined with the derivable `vscode_<port>` cookie this is the classic
Erlang distribution RCE (`net_adm:ping` then `rpc:call(Node, os, cmd, [...])`).

This change confines the distributed node to loopback, inside the existing
`if (this.erlangDistributedNode)` block only (no other `erl`/`rebar3`/`escript`
spawn is affected):

- `-name vscode_<port>@127.0.0.1` instead of `-sname vscode_<port>` — a short
  name resolves to the host's LAN address, which a loopback-bound listener
  refuses, so `-name @127.0.0.1` is what keeps local `remsh` working.
- `-kernel inet_dist_use_interface "{127,0,0,1}"` — binds the distribution
  listener to loopback (the essential part). Double-quoted so the shell
  (`GenericShell` spawns with `shell:true`) passes the tuple as one argument.
- `-env ERL_EPMD_ADDRESS 127.0.0.1` — binds the auto-started epmd to loopback.

The predictable cookie is left unchanged: once the node is loopback-only it is
no longer a network attack surface, and keeping `vscode_<port>` preserves the
current remsh workflow.

## Impact: before vs after

With `erlang.erlangDistributedNode: true`, a node started the way the extension
starts it, probed from the machine's LAN address vs loopback (OTP 27, Linux, in
a container whose LAN address was 172.17.0.2):

| | distribution port from LAN | distribution port from 127.0.0.1 | epmd (4369) from LAN | local `remsh` |
|---|---|---|---|---|
| **before** (`-sname vscode_<port>`) | **reachable** → `net_adm:ping` → `rpc:call(Node, os, cmd, [...])` | reachable | enumerable (reveals node name + port) | works |
| **after** (this change) | **refused** (`econnrefused`) | reachable | not enumerable | works (`pong`) |

Before: anyone who can route TCP to the developer's machine learns the node
name and port from epmd, derives the cookie (`vscode_<port>`), connects, and
runs OS commands as the developer. After: the node is only reachable from the
machine itself; local investigation via `remsh` keeps working.

## How to verify

Automated — `npm test` includes a new suite, `test/test-suite/erlangShellLSP.test.ts`,
which captures the `erl` argument list `ErlangShellLSP.Start` builds (without
spawning) and asserts that distributed mode uses `-name <node>@127.0.0.1`,
`inet_dist_use_interface`, and `ERL_EPMD_ADDRESS`, and that non-distributed mode
adds none of them. It fails on `master` (`-sname`) and passes with this change.

Manual — enable `erlang.erlangDistributedNode`, open an `.erl` file, then from
another host on the LAN:

```
erl -sname probe -setcookie vscode_<port> -noshell \
    -eval 'io:format("~p~n",[net_adm:ping(list_to_atom("vscode_<port>@<host>"))]),halt().'
```

`pong` before this change, `pang` after. On the machine itself,
`erl -name r@127.0.0.1 -setcookie vscode_<port> -remsh vscode_<port>@127.0.0.1`
still connects.

## Scope / not in this PR

- Same-host processes can still reach the loopback node with the predictable
  cookie; this PR removes the network exposure, not same-host access.
